### PR TITLE
Initial repository configuration for PROW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+-include Makefile.prow
+
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -1,0 +1,17 @@
+-include /opt/build-harness/Makefile.prow
+
+.PHONY: push-prow
+push-prow: build-prow
+	docker push ${REPO_URL}/cluster-backup-operator:${VERSION}
+	docker tag ${REPO_URL}/cluster-backup-operator:${VERSION} ${REPO_URL}/cluster-backup-operator:latest
+	docker push ${REPO_URL}/cluster-backup-operator:latest
+
+.PHONY: build-prow
+build-prow: 
+	docker build -f Dockerfile . -t ${REPO_URL}/cluster-backup-operator:${VERSION}
+
+#.PHONY: unit-tests
+#unit-tests:
+#	GOFLAGS="" go test -timeout 120s -v -short ./controllers/clusterclaims
+#	GOFLAGS="" go test -timeout 120s -v -short ./controllers/clusterpools
+	

--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@ approvers:
   - sahare
   - birsanv
   - sdminonne
+  - jnpacker
 reviewers:
   - sahare
   - birsanv
   - sdminonne
+  - jnpacker

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=open-cluster-management_cluster-backup-controller
+sonar.projectName=cluster-backup-controller
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.go.tests.reportPaths=report.json
+sonar.go.coverage.reportPaths=coverage.out
+sonar.externalIssuesReportPaths=gosec.json
+


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Initial configuration changes to allow a PROW build of the cluster-backup-controller image.
* Verified that `docker-build` is still working
* We may remove the unit-test in Makefile.prow
* Add myself to OWNERS for prow onboarding
* Add Sonar cloud properties file