### PR TITLE
clean up resources before restore

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -58,6 +58,14 @@ type RestoreSpec struct {
 	// backup_name points to the name of the backup to be restored
 	// +kubebuilder:validation:Required
 	VeleroCredentialsBackupName *string `json:"veleroCredentialsBackupName"`
+	// +kubebuilder:validation:Optional
+	// set this to true if you want the restore to attempt to delete all
+	// resources created by a previous restore operation
+	// This will allow updating resources that are already on the hub and also part of the new backup
+	// It will also delete resources previously restored but no longer
+	// if not defined, the value is set to false
+	// in the current backup - these resources are no longer available on the cluster where the backup was run
+	CleanupBeforeRestore bool `json:"cleanupBeforeRestore,omitempty"`
 }
 
 // RestoreStatus defines the observed state of Restore

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -45,6 +45,15 @@ spec:
           spec:
             description: RestoreSpec defines the desired state of Restore
             properties:
+              cleanupBeforeRestore:
+                description: set this to true if you want the restore to attempt to
+                  delete all resources created by a previous restore operation This
+                  will allow updating resources that are already on the hub and also
+                  part of the new backup It will also delete resources previously
+                  restored but no longer if not defined, the value is set to false
+                  in the current backup - these resources are no longer available
+                  on the cluster where the backup was run
+                type: boolean
               veleroCredentialsBackupName:
                 description: VeleroCredentialsBackupName is the name of the velero
                   back-up used to restore credentials. Is required, valid values are

--- a/config/samples/cluster_v1beta1_restore.yaml
+++ b/config/samples/cluster_v1beta1_restore.yaml
@@ -3,6 +3,7 @@ kind: Restore
 metadata:
   name: restore-acm
 spec:
+  cleanupBeforeRestore: false
   veleroManagedClustersBackupName: latest
   veleroCredentialsBackupName: latest
   veleroResourcesBackupName: latest

--- a/config/samples/cluster_v1beta1_restore_passive.yaml
+++ b/config/samples/cluster_v1beta1_restore_passive.yaml
@@ -5,6 +5,7 @@ kind: Restore
 metadata:
   name: restore-acm-passive
 spec:
+  cleanupBeforeRestore: false
   veleroManagedClustersBackupName: skip
   veleroCredentialsBackupName: latest
   veleroResourcesBackupName: latest

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -82,7 +82,7 @@ var (
 		"managedclusterset",
 		"managecclustersetbindings",
 		"clusterpool",
-		"hive.openshift.io.clusterclaim",
+		"clusterclaim.hive.openshift.io",
 		"clustercurator",
 		"managedclusterview",
 	}
@@ -92,8 +92,8 @@ var (
 	// the two resources below should already be picked up by the api group selection
 	// they are used here for testing purpose
 	backupResources = []string{
-		"clusterdeployment",
-		"machinepool",
+		"clusterdeployment.hive.openshift.io",
+		"machinepool.hive.openshift.io",
 	}
 
 	backupCredsResources = []string{

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -708,7 +708,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
 						"placement.cluster.open-cluster-management.io")).Should(BeTrue())
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
-						"clusterdeployment")).Should(BeTrue())
+						"clusterdeployment.hive.openshift.io")).Should(BeTrue())
 					Expect(findValue(
 						veleroSchedule.Spec.Template.IncludedResources, //excludedGroup
 						"managedclustermutators.admission.cluster.open-cluster-management.io",

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -107,3 +107,14 @@ func isValidStorageLocationDefined(veleroStorageLocations veleroapi.BackupStorag
 	}
 	return isValidStorageLocation, veleroNamespace
 }
+
+// having a resourceKind.resourceGroup string, return (resourceKind, resourceGroup)
+func getResourceDetails(resourceName string) (string, string) {
+
+	indexOfName := strings.Index(resourceName, ".")
+	if indexOfName > -1 {
+		return resourceName[:indexOfName], resourceName[indexOfName+1:]
+	}
+
+	return resourceName, ""
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -114,6 +115,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// prepare the dynamic client
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to set up dynamic client")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.BackupScheduleReconciler{
 		Client:          mgr.GetClient(),
 		DiscoveryClient: dc,
@@ -128,10 +136,12 @@ func main() {
 		kubeClient = nil
 	}
 	if err = (&controllers.RestoreReconciler{
-		Client:     mgr.GetClient(),
-		KubeClient: kubeClient,
-		Scheme:     mgr.GetScheme(),
-		Recorder:   mgr.GetEventRecorderFor("Restore controller"),
+		Client:          mgr.GetClient(),
+		KubeClient:      kubeClient,
+		DiscoveryClient: dc,
+		DynamicClient:   dyn,
+		Scheme:          mgr.GetScheme(),
+		Recorder:        mgr.GetEventRecorderFor("Restore controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Restore controller")
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Add an optional spec property on restore to allow cleaning up resources before restoring again

`cleanupBeforeRestore` - optional, if not define is set to false ( need more testing before being confident this is working in all cases and not breaking anything )


If cleanupBeforeRestore = true, for each restore file , prior to creating the velero.io.Restore ( so calling the actual restore ) we call a routine which cleans up all resources defined by the restore's backup definition ; resources must have the label `velero.io/backup-name` so they should have been created by another restore. All other resources are kept as is

We need to test resources with finalizers or owned by other resources
For example ClusterDeployment - which I think I tested owns hive secrets and has a finalizer.
I run the secrets restore last to allow them to recreate hive secrets if changed

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Restore
metadata:
  name: restore-acm-passive-activate
spec:
  cleanupBeforeRestore: false. <<<<
  veleroManagedClustersBackupName: latest
  veleroCredentialsBackupName: skip
  veleroResourcesBackupName: skip
```