### PR TITLE
exclude search.open-cluster-management.io api group

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -49,12 +49,18 @@ var (
 	}
 
 	// exclude resources from these api groups
+	// search.open-cluster-management.io is required to be backed up
+	// but since the CRs are created in the MCH NS which is excluded by the resources backup
+	// we want those CRs to be labeled with cluster.open-cluster-management.io/backup
+	// so they are picked up by the resources-generic backup
 	excludedAPIGroups = []string{
 		"admission.cluster.open-cluster-management.io",
 		"admission.work.open-cluster-management.io",
 		"internal.open-cluster-management.io",
 		"operator.open-cluster-management.io",
 		"work.open-cluster-management.io",
+		"search.open-cluster-management.io",
+		"velero.io",
 	}
 	// exclude these CRDs
 	// they are part of the included api groups but are either not needed
@@ -80,7 +86,7 @@ var (
 		"klusterletaddonconfig",
 		"managedclusteraddon",
 		"managedclusterset",
-		"managecclustersetbindings",
+		"managedclustersetbindings",
 		"clusterpool",
 		"clusterclaim.hive.openshift.io",
 		"clustercurator",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Link to conversations :

https://github.com/stolostron/backlog/issues/18514#issuecomment-1006051587
https://github.com/stolostron/backlog/issues/19209#issuecomment-1036245857

Changes : 
- add `search.open-cluster-management.io api` to the. excluded api group; this will make any of the CRDs from `search.open-cluster-management.io api` to not be considered for the acm-resources backup
- since the CRD is not in the `acm-resources` if any CR in this group is tagged with the `cluster.open-cluster-management.io/backup` , they will be picked up by the acm-resources-generic backup, used to get third parties CRDs 

Why we have to specifically remove the `search.open-cluster-management.io api` from this backup ?
- Any resource included in the acm-resources backup, Spec.IncludedResources[] will be excluded by the generic backup - This is to avoid duplicating resources in backups ie : resource with CRD foo.open-cluster-management.io and label annotation `cluster.open-cluster-management.io/backup`  will be picked up by the acm-resources backup ( because it of the CRD prefix ) and by the acm-genric-resources backup ( because of the label )
- Since the `search.open-cluster-management.io` api is prefixed by `open-cluster-management.io api`, the resources would be included in the acm-resources backup, Spec.IncludedResources[] 
- so if we don't specifically exclude the `search.open-cluster-management.io` from the list of valid api-groups, these resources would be added to the acm-resources backup IncludedResources 
- which means will be excluded by the acm-resources-generic, even if the backup label is set