### PR TITLE
enable cleanup resources by default

### DIFF
--- a/config/samples/cluster_v1beta1_restore.yaml
+++ b/config/samples/cluster_v1beta1_restore.yaml
@@ -3,7 +3,7 @@ kind: Restore
 metadata:
   name: restore-acm
 spec:
-  cleanupBeforeRestore: false
+  cleanupBeforeRestore: true
   veleroManagedClustersBackupName: latest
   veleroCredentialsBackupName: latest
   veleroResourcesBackupName: latest

--- a/config/samples/cluster_v1beta1_restore_passive.yaml
+++ b/config/samples/cluster_v1beta1_restore_passive.yaml
@@ -5,7 +5,7 @@ kind: Restore
 metadata:
   name: restore-acm-passive
 spec:
-  cleanupBeforeRestore: false
+  cleanupBeforeRestore: true
   veleroManagedClustersBackupName: skip
   veleroCredentialsBackupName: latest
   veleroResourcesBackupName: latest

--- a/config/samples/cluster_v1beta1_restore_passive_activate.yaml
+++ b/config/samples/cluster_v1beta1_restore_passive_activate.yaml
@@ -7,6 +7,6 @@ kind: Restore
 metadata:
   name: restore-acm-passive-activate
 spec:
-  veleroManagedClustersBackupName: latest
+  veleroManagedClustersBackupName: true
   veleroCredentialsBackupName: skip
   veleroResourcesBackupName: skip


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

update samples to clean up previously restored resources 

`veleroManagedClustersBackupName: true` asks to delete all resources with a velero-name label , which are resources created by a previous backup
We want to clean up before restoring again
This should address resources updated after the previous backup was run or resources delete since then