### PR TITLE
label backups with cluster id and check for collisions

### DIFF
--- a/api/v1beta1/schedule_types.go
+++ b/api/v1beta1/schedule_types.go
@@ -41,6 +41,9 @@ const (
 	// SchedulePhaseUnknown means the schedule has been processed by
 	// the ScheduleController but there are some unknown issues
 	SchedulePhaseUnknown SchedulePhase = "Unknown"
+	// another cluster pushes backups to the same storage location
+	// resulting in a backup collision
+	SchedulePhaseBackupCollision SchedulePhase = "BackupCollision"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -35,6 +35,8 @@ var (
 	BackupScheduleNameLabel string = "cluster.open-cluster-management.io/backup-schedule-name"
 	// BackupScheduleTypeLabel is the label key used to identify the type of the backup schedule
 	BackupScheduleTypeLabel string = "cluster.open-cluster-management.io/backup-schedule-type"
+	// BackupScheduleTypeLabel is the label key used to identify the type of the backup schedule
+	BackupScheduleClusterUIDLabel string = "cluster.open-cluster-management.io/backup-schedule-cluster-uid"
 )
 var (
 	// include resources from these api groups

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -35,8 +35,8 @@ var (
 	BackupScheduleNameLabel string = "cluster.open-cluster-management.io/backup-schedule-name"
 	// BackupScheduleTypeLabel is the label key used to identify the type of the backup schedule
 	BackupScheduleTypeLabel string = "cluster.open-cluster-management.io/backup-schedule-type"
-	// BackupScheduleTypeLabel is the label key used to identify the type of the backup schedule
-	BackupScheduleClusterUIDLabel string = "cluster.open-cluster-management.io/backup-schedule-cluster-uid"
+	// BackupScheduleClusterUIDLabel is the label key used to identify the cluster id that generated the backup
+	BackupScheduleClusterLabel string = "cluster.open-cluster-management.io/backup-cluster"
 )
 var (
 	// include resources from these api groups

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -207,9 +207,10 @@ func (r *BackupScheduleReconciler) Reconcile(
 			// we risk a backup collision, as more then one cluster seems to be
 			// backing up data in the same location
 			msg := fmt.Sprintf(
-				"Backup %s, from cluster with id [%s] is using the same storage location. Collision with this cluster backup!",
+				"Backup %s, from cluster with id [%s] is using the same storage location. Collision with current cluster [%s] backup!",
 				lastBackup.GetName(),
 				lastBackup.GetLabels()[BackupScheduleClusterLabel],
+				veleroScheduleList.Items[0].GetLabels()[BackupScheduleClusterLabel],
 			)
 			scheduleLogger.Info(msg)
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -205,5 +205,5 @@ func getHubIdentification(
 	if err != nil || item == nil {
 		return uid, err
 	}
-	return string(item.GetUID()), nil
+	return string(item.GetLabels()["clusterID"]), nil
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -175,9 +175,9 @@ func getGenericCRDFromAPIGroups(
 	return resources, nil
 }
 
-// return hub url, used to annotate backup schedules
-// to know what hub had created the backups
-// when switching active - passive clusters
+// return hub uid, used to annotate backup schedules
+// to know what hub is pushing the backups to the storage location
+// info used when switching active - passive clusters
 func getHubIdentification(
 	ctx context.Context,
 	dc discovery.DiscoveryInterface,

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -188,8 +188,8 @@ func getHubIdentification(
 	uid := "unknown"
 	logger := log.FromContext(ctx)
 	groupKind := schema.GroupKind{
-		Group: "cluster.open-cluster-management.io",
-		Kind:  "ManagedCluster",
+		Group: "config.openshift.io",
+		Kind:  "ClusterVersion",
 	}
 	mapping, err := mapper.RESTMapping(groupKind, "")
 	if err != nil {
@@ -201,9 +201,9 @@ func getHubIdentification(
 	if dr == nil {
 		return uid, nil
 	}
-	item, err := dr.Get(ctx, "local-cluster", v1.GetOptions{})
-	if err != nil || item == nil {
+	items, err := dr.List(ctx, v1.ListOptions{})
+	if err != nil || items == nil {
 		return uid, err
 	}
-	return string(item.GetLabels()["clusterID"]), nil
+	return string(items.Items[0].GetUID()), nil
 }


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/19469

Changes 
1. introduce a new backup status `SchedulePhaseBackupCollision`
2. annotate all backup schedules with the current cluster ID ( use `ClusterVersion` uid ) 
```
	// BackupScheduleClusterUIDLabel is the label key used to identify the cluster id that generated the backup
	BackupScheduleClusterLabel string = "cluster.open-cluster-management.io/backup-cluster"

```

sample labels 

```
 labels:
    cluster.open-cluster-management.io/backup-cluster: 86941453-3823-4f03-8bdd-082297d32129 <<<<<<
    cluster.open-cluster-management.io/backup-schedule-name: schedule-acm
    cluster.open-cluster-management.io/backup-schedule-type: credentialsCluster

```

3. when creating a new acm backupscehdule, label velero io schedules with the above label
4. on reconcile, if the acm backupschedule exists ( so NOT when creating a new schedule because in this case we assume the user specifically wants to backup from this cluster) then check if the latest resources backup is from the same cluster. If not, set the backupschedule Phase to SchedulePhaseBackupCollision

Let the backups still go through; I am going to update the policy to alert if the backupschedule Phase is BackupCollision

```
oc get backupschedule -A                                
NAMESPACE       NAME           PHASE             MESSAGE
openshift-adp   schedule-acm   BackupCollision   Backup acm-resources-schedule-20220214161948, from cluster with id [d93d09b6-3ca1-449f-9c30-dcccf2848485] is using the same storage location. Collision with this cluster backup!
```

5. Reconcile every hour to look for new collisions , using `collisionControlInterval`
