### PR TITLE
allow schedule to get through when phase is empty

### DIFF
--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -207,6 +207,7 @@ func (r *BackupScheduleReconciler) Reconcile(
 	}
 
 	if len(veleroScheduleList.Items) > 0 &&
+		backupSchedule.Status.Phase != "" &&
 		backupSchedule.Status.Phase != v1beta1.SchedulePhaseNew {
 		if isThisTheOwner, lastBackup := r.scheduleOwnsLatestStorageBackups(ctx,
 			&veleroScheduleList.Items[0]); !isThisTheOwner {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/19469

When the backupschedule is first created, the state could be empty or New
For these 2 cases don't check on collision with other backups