### PR TITLE
do not cleanup managed cluster resources

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -184,6 +184,12 @@ func prepareRestoreForBackup(
 	deleteOptions v1.DeleteOptions,
 ) {
 	logger := log.FromContext(ctx)
+
+	if restoreType == ManagedClusters {
+		logger.Info("skipping cleanup of managed clusters activation data")
+		return
+	}
+
 	logger.Info("enter prepareForRestoreResources for " + string(restoreType))
 
 	labelSelector := ""

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -608,13 +608,5 @@ func (r *RestoreReconciler) prepareForRestore(
 			prepareRestoreForBackup(ctx, reconcileArgs,
 				acmRestore.Spec.CleanupBeforeRestore, key, backupsForVeleroRestores[key], deleteOptions)
 		}
-		if backupsForVeleroRestores[ManagedClusters] == nil &&
-			backupsForVeleroRestores[Resources] != nil {
-			// when cleaning up resources also clean up managed clusters resources
-			if _, veleroBackup, err := r.getVeleroBackupName(ctx, &acmRestore, Resources, latestBackupStr); err != nil {
-				prepareRestoreForBackup(ctx, reconcileArgs,
-					acmRestore.Spec.CleanupBeforeRestore, Resources, veleroBackup, deleteOptions)
-			}
-		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Don't run a resources clean up when restoring managed cluster data
This could affect the cluster lifecycle; we also need to make sure we don't touch the local-cluster which is a global resource packaged with the acm-managed-clusters backup

https://github.com/stolostron/backlog/issues/19928