### PR TITLE
create a dummy backup for policy validation of enabled backups

### DIFF
--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -534,8 +534,13 @@ func (r *RestoreReconciler) retrieveRestoreDetails(
 
 	restoreLogger := log.FromContext(ctx)
 
-	restoreKeys := make([]ResourceType, 0, len(veleroScheduleNames))
+	restoreKeys := make([]ResourceType, 0, len(veleroScheduleNames)-1) // ignore validation backup
 	for key := range veleroScheduleNames {
+		if key == ValidationSchedule {
+			// ignore validation backup; this is used for the policy
+			// to validate that there are backups schedules enabled
+			continue
+		}
 		restoreKeys = append(restoreKeys, key)
 	}
 	// sort restores to restore last credentials, first resources

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -134,7 +134,10 @@ func isScheduleSpecUpdated(
 	for i := range schedules.Items {
 		veleroSchedule := &schedules.Items[i]
 
-		if veleroSchedule.Spec.Template.TTL.Duration != backupSchedule.Spec.VeleroTTL.Duration {
+		if veleroSchedule.Name != veleroScheduleNames[ValidationSchedule] &&
+			veleroSchedule.Spec.Template.TTL.Duration != backupSchedule.Spec.VeleroTTL.Duration {
+			// validation backup TTL should be ignored here
+			// since that one is using the schedule's cron job interval
 			return true
 		}
 		if veleroSchedule.Spec.Schedule != backupSchedule.Spec.VeleroSchedule {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/19776

Design: 
- create a dummy backup which sets the TTL to be the backup schedule cron job + 5 min
- this dummy backup (acm-validation-policy-schedule) will delete itself 5 min after the owner backup would start a new set of backups
- if the owner backup no longer creates backups, then after the last deletion there will be no acm-validation-policy-schedule backup in the storage location
- if there are no backupschedules writing backups at that storage location then there are going to be no acm-validation-policy-schedule backups ( they delete themself using the cron time )
- the policy checks for at least one instance of a acm-validation-policy-schedule backup at the storage location; if none found, it will throw an exception , it means that there are no primary hubs backing up data as expected

Example : 
Create this backup schedule 

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: BackupSchedule
metadata:
  name: schedule-acm-1
  namespace: openshift-adp
spec:
  veleroSchedule: 0 */2 * * *
  veleroTtl: 72h
```

This triggers the creation of the 6 backups
There is going to be a 7' schedule, for the acm-validation-policy-schedule
This one is set to 

```
apiVersion: velero.io/v1
kind: Schedule
metadata:
  name: acm-validation-policy-schedule
  namespace: openshift-adp
spec:
  schedule: 0 */2 * * *
  ttl: 2h <<< instead of 27h, this backup expires as soon as a new cron job should run
```