### PR TITLE
delete expired backups and update readme

### DIFF
--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -86,6 +86,10 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	restoreLogger := log.FromContext(ctx)
 	restore := &v1beta1.Restore{}
 
+	// velero doesn't delete expired backups if they are in FailedValidation
+	// workaround and delete expired or invalid validation backups them now
+	cleanupExpiredValidationBackups(ctx, req.Namespace, r.Client)
+
 	if err := r.Get(ctx, req.NamespacedName, restore); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -112,6 +112,10 @@ func (r *BackupScheduleReconciler) Reconcile(
 	scheduleLogger := log.FromContext(ctx)
 	backupSchedule := &v1beta1.BackupSchedule{}
 
+	// velero doesn't delete expired backups if they are in FailedValidation
+	// workaround and delete expired or invalid validation backups them now
+	cleanupExpiredValidationBackups(ctx, req.Namespace, r.Client)
+
 	if err := r.Get(ctx, req.NamespacedName, backupSchedule); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -183,8 +183,9 @@ var _ = Describe("BackupSchedule controller", func() {
 		aFewSecondsAgo := metav1.NewTime(time.Now().Add(-2 * time.Second))
 
 		//create 3 sets of backups, for each timestamp
-		for _, timestampStr := range backupTimestamps {
+		for i, timestampStr := range backupTimestamps {
 			for _, value := range veleroScheduleNames {
+
 				backup := veleroapi.Backup{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "velero/v1",
@@ -203,6 +204,14 @@ var _ = Describe("BackupSchedule controller", func() {
 						StartTimestamp: &aFewSecondsAgo,
 						Errors:         0,
 					},
+				}
+
+				if value == ValidationSchedule {
+
+					if i == len(backupTimestamps)-1 {
+						// mark it as expired
+						backup.Status.Expiration = &oneHourAgo
+					}
 				}
 
 				veleroBackups = append(veleroBackups, backup)


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/19776

Delete expired acm-validation-policy-schedule backups

// clean up expired validation backups, workaround for
// velero doesn't delete expired backups if they are in FailedValidation
// or storage location is no longer valid
https://coreos.slack.com/archives/C0144ECKUJ0/p1646405908138569