### PR TITLE
Fix the index of backup schedule names in the swap after sorting them

### DIFF
--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -318,8 +318,9 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 	sort.Sort(SortResourceType(scheduleKeys))
 	// swap the last two items to put the resources last, after the resourcesGeneric
 	swapF := reflect.Swapper(scheduleKeys)
-	if len(scheduleKeys) > 1 {
-		swapF(len(scheduleKeys)-2, len(scheduleKeys)-1)
+	if len(scheduleKeys) > 5 {
+		// swap resources and resourcesGeneric, so resources is the last backup to be created
+		swapF(4, 5)
 	}
 
 	// loop through schedule names to create a Velero schedule per type


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

The index of backup schedule names were changed after ValidationSchedule was added