### PR TITLE
generic resources restored in activation phase

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -76,16 +76,16 @@ var (
 	// they are part of the included api groups but are either not needed
 	// or they are being recreated by owner resources, which are also backed up
 	excludedCRDs = []string{
-		"clustermanagementaddon",
-		"observabilityaddon",
-		"applicationmanager",
-		"certpolicycontroller",
-		"iampolicycontroller",
-		"policycontroller",
-		"searchcollector",
-		"workmanager",
-		"backupschedule",
-		"restore",
+		"clustermanagementaddon.addon.open-cluster-management.io",
+		"observabilityaddon.observability.open-cluster-management.io",
+		"applicationmanager.agent.open-cluster-management.io",
+		"certpolicycontroller.agent.open-cluster-management.io",
+		"iampolicycontroller.agent.open-cluster-management.io",
+		"policycontroller.agent.open-cluster-management.io",
+		"searchcollector.agent.open-cluster-management.io",
+		"workmanager.agent.open-cluster-management.io",
+		"backupschedule.cluster.open-cluster-management.io",
+		"restore.cluster.open-cluster-management.io",
 		"clusterclaim.cluster.open-cluster-management.io",
 		"discoveredcluster.discovery.open-cluster-management.io",
 	}

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -243,7 +243,7 @@ func (r *BackupScheduleReconciler) Reconcile(
 				}
 			}
 
-			return ctrl.Result{RequeueAfter: collisionControlInterval}, errors.Wrap(
+			return ctrl.Result{}, errors.Wrap(
 				r.Client.Status().Update(ctx, backupSchedule),
 				msg,
 			)


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/20486

backup should allow third party to backup generic resources under activation data

Changes :

- introduced a new value for for the backup label to allow restroring resources in the activation phase
when you add the `cluster.open-cluster-management.io/backup` label to a resource, this resource is automatically backed up under the `acm-resources-generic-schedule` backup. If any of these resources need to be restored only when the managed clusters are moved to the new hub, so when the `veleroManagedClustersBackupName:latest` is used on the restored resource, then you have to set the label value to `cluster-activation`. This will ensure the resource is not restored unless the managed cluster activation is called.
Example :
```yaml
apiVersion: my.group/v1alpha1
kind: MyResource
metadata:
  labels:
    cluster.open-cluster-management.io/backup: cluster-activation
``` 
- remove RequeueAfter: collisionControlInterval when backupschedule is in collision phase
- used fully qualified names for excludedCRDs resources ( use apigroup ); easier to debug and see what resources is owned by what apigroup