### PR TITLE
Look for backups within a time range when backup name is set

### DIFF
--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -1082,7 +1082,7 @@ var _ = Describe("Basic Restore controller", func() {
 			}, timeout, interval).Should(BeEquivalentTo(v1beta1.RestorePhaseError))
 			Expect(
 				createdRestore.Status.LastMessage,
-			).Should(BeIdenticalTo("cannot find acm-credentials-schedule-name Velero Backup: Backup.velero.io \"acm-credentials-schedule-name\" not found"))
+			).Should(BeIdenticalTo("cannot find invalid-backup-name Velero Backup: Backup.velero.io \"invalid-backup-name\" not found"))
 
 			// createdRestore above is has RestorePhaseError status
 			// the following restore should be ignored


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

- When backup name is set in restore resource (for example veleroCredentialsBackupName: acm-credentials-schedule-20220309134806 for the following case), for CredentialsHive, CredentialsCluster, ResourcesGeneric types, try to find a backup with StartTimestamp within 30 seconds of the timestamp suffix in the requested backup name.

Note: For the following test case, the difference between the StartTimestamp of CredentialsHive backup and the target timestamp suffix in Credential backup name was 30 seconds even though based on their name it was expected to be 6 seconds.
[acm-credentials-hive-schedule-20220309134800]
[acm-credentials-schedule-20220309134806]

- Fixes a bug and its unit test, when calling retrieveRestoreDetails, if error, return error before checking if there are any veleroRestoresToCreate 