### PR TITLE
exclude cluster-backup NS

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -88,8 +88,6 @@ var (
 		"restore.cluster.open-cluster-management.io",
 		"clusterclaim.cluster.open-cluster-management.io",
 		"discoveredcluster.discovery.open-cluster-management.io",
-		"clusterimageset.hive.openshift.io",
-		"hiveconfig.hive.openshift.io",
 	}
 
 	// resources used to activate the connection between hub and managed clusters - activation resources
@@ -146,6 +144,7 @@ func setResourcesBackupInfo(
 	ctx context.Context,
 	veleroBackupTemplate *veleroapi.BackupSpec,
 	resourcesToBackup []string,
+	backupNS string,
 	c client.Client,
 ) {
 
@@ -155,6 +154,12 @@ func setResourcesBackupInfo(
 	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
 		veleroBackupTemplate.ExcludedNamespaces,
 		"local-cluster",
+	)
+
+	// exclude backup chart NS
+	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
+		veleroBackupTemplate.ExcludedNamespaces,
+		backupNS,
 	)
 
 	for i := range resourcesToBackup { // acm resources

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -376,7 +376,8 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 		case CredentialsCluster:
 			setCredsBackupInfo(ctx, veleroBackupTemplate, r.Client, string(ClusterSecret))
 		case Resources:
-			setResourcesBackupInfo(ctx, veleroBackupTemplate, resourcesToBackup, r.Client)
+			setResourcesBackupInfo(ctx, veleroBackupTemplate, resourcesToBackup,
+				backupSchedule.Namespace, r.Client)
 		case ResourcesGeneric:
 			setGenericResourcesBackupInfo(ctx, veleroBackupTemplate, resourcesToBackup, r.Client)
 		case ValidationSchedule:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -133,6 +133,8 @@ var _ = BeforeSuite(func() {
 		GroupVersion: "hive.openshift.io/v1beta1",
 		APIResources: []metav1.APIResource{
 			{Name: "dnszones", Namespaced: false, Kind: "DNSZone"},
+			{Name: "clusterimageset", Namespaced: false, Kind: "ClusterImageSet"},
+			{Name: "hiveconfig", Namespaced: false, Kind: "HiveConfig"},
 		},
 	}
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/20857

Changes:
- include clusterimageset, hiveconfig but don't clean them up
- exclude cluster-backup NS
- exclude from cleanup any resource with a label of installer.name=multiclusterhub ( in case there are other charts installed by MCH in a separate ns then the MCH )
- exclude from cleanup resources with velero.io/exclude-from-backup=true, they are not backed up