### PR TITLE
backup CR from agent-install.openshift.io group

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -55,6 +55,7 @@ var (
 		"app.k8s.io",
 		"core.observatorium.io",
 		"hive.openshift.io",
+		"agent-install.openshift.io",
 	}
 
 	// exclude resources from these api groups


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/20903

The following resources will be backup up by default

agents                                                               agent-install.openshift.io                     true         Agent
agentserviceconfigs                                                  agent-install.openshift.io                     false        AgentServiceConfig
infraenvs                                                            agent-install.openshift.io                     true         InfraEnv
nmstateconfigs                                                       agent-install.openshift.io                     true         NMStateConfig