### PR TITLE
fix finalizers patch for global resources

### DIFF
--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -757,14 +757,7 @@ func (r *RestoreReconciler) prepareForRestore(
 				additionalLabel,
 			)
 		}
-		if key == ResourcesGeneric &&
-			veleroRestoresToCreate[ManagedClusters] == nil {
-			// managed clusters not restored
-			// don't clean up resources with cluster-activation label
-			additionalLabel = "cluster.open-cluster-management.io/backup," +
-				"cluster.open-cluster-management.io/backup notin (cluster-activation)"
 
-		}
 		prepareRestoreForBackup(
 			ctx,
 			restoreOptions,


### PR DESCRIPTION
Changes: 
- fix the patch call for deleting finalizers for global objects
- clean up managed cluster resources when restoring just resources ; they need to be cleaned up to match a passive config, will be added when the managed clusters are restored