### PR TITLE
execute restore if cleanup fails; add more events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Cluster Back up and Restore Operator.
         - [Restoring activation resources](#restoring-activation-resources)
         - [Restoring all resources](#restoring-all-resources)
       - [Cleaning up the hub before restore](#cleaning-up-the-hub-before-restore)
+      - [View restore events](#view-restore-events)
     - [Backup validation using a Policy](#backup-validation-using-a-policy)
       - [Pod validation](#pod-validation)
       - [Backup Storage validation](#backup-storage-validation)
@@ -320,6 +321,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Restore
 metadata:
   name: restore-acm
+  namespace: open-cluster-management-backup
 spec:
   cleanupBeforeRestore: CleanupRestored
   veleroManagedClustersBackupName: latest
@@ -327,6 +329,41 @@ spec:
   veleroResourcesBackupName: latest
 ```
 
+### View restore events
+
+Use the `oc describe -n <oadp-n> <restore-name>` command to get information about restore events.
+A sample output is shown below
+
+```yaml
+Spec:
+  Cleanup Before Restore:               CleanupRestored
+  Restore Sync Interval:                4m
+  Sync Restore With New Backups:        true
+  Velero Credentials Backup Name:       latest
+  Velero Managed Clusters Backup Name:  skip
+  Velero Resources Backup Name:         latest
+Status:
+  Last Message:                     Velero restores have run to completion, restore will continue to sync with new backups
+  Phase:                            Enabled
+  Velero Credentials Restore Name:  example-acm-credentials-schedule-20220325220057
+  Velero Resources Restore Name:    example-acm-resources-schedule-20220325220057
+Events:
+  Type    Reason                                                 Age   From                Message
+  ----    ------                                                 ----  ----                -------
+  Normal  Processing restore request                             89s   Restore controller  Restore sync found new backups
+  Normal  Prepare to restore, cleaning up resources for backup:  89s   Restore controller  acm-resources-generic-schedule-20220325220057
+  Normal  Prepare to restore, cleaning up resources for backup:  66s   Restore controller  acm-resources-schedule-20220325220057
+  Normal  Prepare to restore, cleaning up resources for backup:  61s   Restore controller  acm-credentials-hive-schedule-20220325220057
+  Normal  Prepare to restore, cleaning up resources for backup:  60s   Restore controller  acm-credentials-cluster-schedule-20220325220057
+  Normal  Prepare to restore, cleaning up resources for backup:  59s   Restore controller  acm-credentials-schedule-20220325220057
+  Normal  Velero restore created:                                58s   Restore controller  example-acm-credentials-hive-schedule-20220325220057
+  Normal  Velero restore created:                                58s   Restore controller  example-acm-credentials-cluster-schedule-20220325220057
+  Normal  Velero restore created:                                58s   Restore controller  example-acm-credentials-schedule-20220325220057
+  Normal  Velero restore created:                                58s   Restore controller  example-acm-resources-generic-schedule-20220325220057
+  Normal  Velero restore created:                                58s   Restore controller  example-acm-resources-schedule-20220325220057
+  Normal  Processing restore request                             43s   Restore controller  Restore sync found no new backups
+
+```
 
 ## Backup validation using a Policy
 

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -240,8 +241,9 @@ func deleteDynamicResource(
 }
 
 // clean up resources for the restored backup resources
-func prepareRestoreForBackup(
+func (r *RestoreReconciler) prepareRestoreForBackup(
 	ctx context.Context,
+	acmRestore *v1beta1.Restore,
 	restoreOptions RestoreOptions,
 	restoreType ResourceType,
 	veleroBackup *veleroapi.Backup,
@@ -250,6 +252,13 @@ func prepareRestoreForBackup(
 	logger := log.FromContext(ctx)
 
 	logger.Info("enter prepareForRestoreResources for " + string(restoreType))
+
+	r.Recorder.Event(
+		acmRestore,
+		corev1.EventTypeNormal,
+		"Prepare to restore, cleaning up resources for backup:",
+		veleroBackup.Name,
+	)
 
 	labelSelector := ""
 	if restoreOptions.cleanupType == v1beta1.CleanupTypeRestored ||


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/21170

Changes:
- allow restore to run to completion even if the cleanup returned failures. If we don't do that, we can clean up previous restored resources and not add them back
- add more restore events, to follow the flow; example output
- update readme to document the restore events

```
 oc describe restore -n open-cluster-management-backup example
Name:         example
Namespace:    open-cluster-management-backup
Labels:       <none>
Annotations:  <none>
API Version:  cluster.open-cluster-management.io/v1beta1
Kind:         Restore
Metadata:
  Creation Timestamp:  2022-03-26T19:44:49Z
  Generation:          1
  Managed Fields:
    API Version:  cluster.open-cluster-management.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:cleanupBeforeRestore:
        f:restoreSyncInterval:
        f:syncRestoreWithNewBackups:
        f:veleroCredentialsBackupName:
        f:veleroManagedClustersBackupName:
        f:veleroResourcesBackupName:
    Manager:      Mozilla
    Operation:    Update
    Time:         2022-03-26T19:44:49Z
    API Version:  cluster.open-cluster-management.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        .:
        f:lastMessage:
        f:phase:
        f:veleroCredentialsRestoreName:
        f:veleroResourcesRestoreName:
    Manager:         __debug_bin
    Operation:       Update
    Subresource:     status
    Time:            2022-03-26T19:45:21Z
  Resource Version:  12151491
  UID:               761c725e-731d-42f7-b0ef-547af0789a3b
Spec:
  Cleanup Before Restore:               CleanupRestored
  Restore Sync Interval:                4m
  Sync Restore With New Backups:        true
  Velero Credentials Backup Name:       latest
  Velero Managed Clusters Backup Name:  skip
  Velero Resources Backup Name:         latest
Status:
  Last Message:                     Velero restores have run to completion, restore will continue to sync with new backups
  Phase:                            Enabled
  Velero Credentials Restore Name:  example-acm-credentials-schedule-20220325220057
  Velero Resources Restore Name:    example-acm-resources-schedule-20220325220057
Events:
  Type    Reason                                                 Age                From                Message
  ----    ------                                                 ----               ----                -------
  Normal  Processing restore request                             4m54s              Restore controller  Restore sync found new backups
  Normal  Prepare to restore, cleaning up resources for backup:  4m54s              Restore controller  acm-resources-generic-schedule-20220325220057
  Normal  Prepare to restore, cleaning up resources for backup:  4m31s              Restore controller  acm-resources-schedule-20220325220057
  Normal  Prepare to restore, cleaning up resources for backup:  4m26s              Restore controller  acm-credentials-hive-schedule-20220325220057
  Normal  Prepare to restore, cleaning up resources for backup:  4m25s              Restore controller  acm-credentials-cluster-schedule-20220325220057
  Normal  Prepare to restore, cleaning up resources for backup:  4m24s              Restore controller  acm-credentials-schedule-20220325220057
  Normal  Velero restore created:                                4m23s              Restore controller  example-acm-credentials-hive-schedule-20220325220057
  Normal  Velero restore created:                                4m23s              Restore controller  example-acm-credentials-cluster-schedule-20220325220057
  Normal  Velero restore created:                                4m23s              Restore controller  example-acm-credentials-schedule-20220325220057
  Normal  Velero restore created:                                4m23s              Restore controller  example-acm-resources-generic-schedule-20220325220057
  Normal  Velero restore created:                                4m23s              Restore controller  example-acm-resources-schedule-20220325220057
  Normal  Processing restore request                             8s (x2 over 4m8s)  Restore controller  Restore sync found no new backups
```