### PR TITLE
exclude local-cluster managedcluster from backup

### DIFF
--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -464,6 +464,14 @@ var _ = Describe("BackupSchedule controller", func() {
 				createdBackupSchedule.Status.VeleroScheduleResources.Spec.Template.TTL,
 			).Should(Equal(metav1.Duration{Duration: time.Hour * 72}))
 
+			// local-cluster managed cluster should have this label velero.io/exclude-from-backup = "true"
+			localcluster := &clusterv1.ManagedCluster{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "local-cluster"}, localcluster)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(localcluster.GetLabels()["velero.io/exclude-from-backup"]).To(BeIdenticalTo("true"))
+
 			// update schedule, it should trigger velero schedules deletion
 			createdBackupSchedule.Spec.VeleroTTL = metav1.Duration{Duration: time.Hour * 150}
 			Expect(


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

related to https://github.com/stolostron/backlog/issues/21054

Until the velero.io/exclude-from-backup=true is set on the local-cluster by the installer team, I am adding the managed-cluster resource to the prepareForBackup routine and add this label there
I will take out the code as soon as the label is added when the cluster is created

This is to fix this restore warning ( at the moment velero doesn't attempt to update existing resources, which is why this is no t affecting the restore procedure; when velero will attempt to update existing resources with restore content, which is post 2.5, the local-cluster resource would be updated with the restore content, and the restore cluster is messed up )
`"warnings":{"cluster":["could not restore, managedclusters.cluster.open-cluster-management.io \"local-cluster\" already exists. Warning: the in-cluster version is different than the backed-up version."]
`