### PR TITLE
Fix the phase update when sync is set to disabled

### DIFF
--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -274,7 +274,8 @@ func setRestorePhase(
 	restore *v1beta1.Restore,
 ) v1beta1.RestorePhase {
 
-	if restore.Status.Phase == v1beta1.RestorePhaseEnabled {
+	if restore.Status.Phase == v1beta1.RestorePhaseEnabled &&
+		restore.Spec.SyncRestoreWithNewBackups {
 		return restore.Status.Phase
 	}
 

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -903,7 +903,7 @@ var _ = Describe("Basic Restore controller", func() {
 					Namespace: veleroNamespace.Name,
 				},
 				Spec: v1beta1.RestoreSpec{
-					SyncRestoreWithNewBackups:       false,
+					SyncRestoreWithNewBackups:       true,
 					CleanupBeforeRestore:            v1beta1.CleanupTypeRestored,
 					VeleroManagedClustersBackupName: &skipRestore,
 					VeleroCredentialsBackupName:     &latestBackup,


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

Fixes the status phase update when syncRestoreWithNewBackups is updated from true to false, in this case the sync should stop and the phase should update from Enabled to Finished/FinishedWithErrors 