### PR TITLE
update events on restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,23 +346,42 @@ Spec:
 Status:
   Last Message:                     Velero restores have run to completion, restore will continue to sync with new backups
   Phase:                            Enabled
-  Velero Credentials Restore Name:  example-acm-credentials-schedule-20220325220057
-  Velero Resources Restore Name:    example-acm-resources-schedule-20220325220057
+  Velero Credentials Restore Name:  example-acm-credentials-schedule-20220406171919
+  Velero Resources Restore Name:    example-acm-resources-schedule-20220406171920
 Events:
-  Type    Reason                                                 Age   From                Message
-  ----    ------                                                 ----  ----                -------
-  Normal  Processing restore request                             89s   Restore controller  Restore sync found new backups
-  Normal  Prepare to restore, cleaning up resources for backup:  89s   Restore controller  acm-resources-generic-schedule-20220325220057
-  Normal  Prepare to restore, cleaning up resources for backup:  66s   Restore controller  acm-resources-schedule-20220325220057
-  Normal  Prepare to restore, cleaning up resources for backup:  61s   Restore controller  acm-credentials-hive-schedule-20220325220057
-  Normal  Prepare to restore, cleaning up resources for backup:  60s   Restore controller  acm-credentials-cluster-schedule-20220325220057
-  Normal  Prepare to restore, cleaning up resources for backup:  59s   Restore controller  acm-credentials-schedule-20220325220057
-  Normal  Velero restore created:                                58s   Restore controller  example-acm-credentials-hive-schedule-20220325220057
-  Normal  Velero restore created:                                58s   Restore controller  example-acm-credentials-cluster-schedule-20220325220057
-  Normal  Velero restore created:                                58s   Restore controller  example-acm-credentials-schedule-20220325220057
-  Normal  Velero restore created:                                58s   Restore controller  example-acm-resources-generic-schedule-20220325220057
-  Normal  Velero restore created:                                58s   Restore controller  example-acm-resources-schedule-20220325220057
-  Normal  Processing restore request                             43s   Restore controller  Restore sync found no new backups
+  Type    Reason                   Age   From                Message
+  ----    ------                   ----  ----                -------
+  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-credentials-hive-schedule-20220406155817
+  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-credentials-cluster-schedule-20220406155817
+  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-credentials-schedule-20220406155817
+  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-resources-generic-schedule-20220406155817
+  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-resources-schedule-20220406155817
+  Normal  Velero restore created:  74m   Restore controller  example-acm-credentials-schedule-20220406155817
+  Normal  Velero restore created:  74m   Restore controller  example-acm-resources-generic-schedule-20220406155817
+  Normal  Velero restore created:  74m   Restore controller  example-acm-resources-schedule-20220406155817
+  Normal  Velero restore created:  74m   Restore controller  example-acm-credentials-cluster-schedule-20220406155817
+  Normal  Velero restore created:  74m   Restore controller  example-acm-credentials-hive-schedule-20220406155817
+  Normal  Prepare to restore:      64m   Restore controller  Cleaning up resources for backup acm-resources-schedule-20220406165328
+  Normal  Prepare to restore:      62m   Restore controller  Cleaning up resources for backup acm-credentials-hive-schedule-20220406165328
+  Normal  Prepare to restore:      62m   Restore controller  Cleaning up resources for backup acm-credentials-cluster-schedule-20220406165328
+  Normal  Prepare to restore:      62m   Restore controller  Cleaning up resources for backup acm-credentials-schedule-20220406165328
+  Normal  Prepare to restore:      62m   Restore controller  Cleaning up resources for backup acm-resources-generic-schedule-20220406165328
+  Normal  Velero restore created:  61m   Restore controller  example-acm-credentials-cluster-schedule-20220406165328
+  Normal  Velero restore created:  61m   Restore controller  example-acm-credentials-schedule-20220406165328
+  Normal  Velero restore created:  61m   Restore controller  example-acm-resources-generic-schedule-20220406165328
+  Normal  Velero restore created:  61m   Restore controller  example-acm-resources-schedule-20220406165328
+  Normal  Velero restore created:  61m   Restore controller  example-acm-credentials-hive-schedule-20220406165328
+  Normal  Prepare to restore:      38m   Restore controller  Cleaning up resources for backup acm-resources-generic-schedule-20220406171920
+  Normal  Prepare to restore:      38m   Restore controller  Cleaning up resources for backup acm-resources-schedule-20220406171920
+  Normal  Prepare to restore:      36m   Restore controller  Cleaning up resources for backup acm-credentials-hive-schedule-20220406171919
+  Normal  Prepare to restore:      36m   Restore controller  Cleaning up resources for backup acm-credentials-cluster-schedule-20220406171919
+  Normal  Prepare to restore:      36m   Restore controller  Cleaning up resources for backup acm-credentials-schedule-20220406171919
+  Normal  Velero restore created:  36m   Restore controller  example-acm-credentials-cluster-schedule-20220406171919
+  Normal  Velero restore created:  36m   Restore controller  example-acm-credentials-schedule-20220406171919
+  Normal  Velero restore created:  36m   Restore controller  example-acm-resources-generic-schedule-20220406171920
+  Normal  Velero restore created:  36m   Restore controller  example-acm-resources-schedule-20220406171920
+  Normal  Velero restore created:  36m   Restore controller  example-acm-credentials-hive-schedule-20220406171919
+
 
 ```
 

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -257,8 +257,8 @@ func (r *RestoreReconciler) prepareRestoreForBackup(
 	r.Recorder.Event(
 		acmRestore,
 		corev1.EventTypeNormal,
-		"Prepare to restore, cleaning up resources for backup:",
-		veleroBackup.Name,
+		"Prepare to restore:",
+		"Cleaning up resources for backup "+veleroBackup.Name,
 	)
 
 	labelSelector := ""

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -504,22 +504,9 @@ func (r *RestoreReconciler) initVeleroRestores(
 			// allow that now
 			restoreOnlyManagedClusters = true
 		} else {
-			r.Recorder.Event(
-				restore,
-				v1.EventTypeNormal,
-				"Processing restore request",
-				"Restore sync found no new backups",
-			)
 			return nil
 		}
 	}
-
-	r.Recorder.Event(
-		restore,
-		v1.EventTypeNormal,
-		"Processing restore request",
-		"Restore sync found new backups",
-	)
 
 	// loop through resourceTypes to create a Velero restore per type
 	veleroRestoresToCreate, backupsForVeleroRestores, err := r.retrieveRestoreDetails(


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

- Updated restore events to remove the message for looking on new backups; the events are grouped together and the result is not helpful. It also generates a lot of messages ( ie every 20min if your are syncing every 20 min )
- updated events message 

Output removed 
 ```
Normal  Processing restore request                             11m (x10 over 138m)  Restore controller  Restore sync found new backups
  Normal  Processing restore request                             95s (x16 over 133m)  Restore controller  Restore sync found no new backups
```

Current output 

```
Status:
  Last Message:                     Velero restores have run to completion, restore will continue to sync with new backups
  Phase:                            Enabled
  Velero Credentials Restore Name:  example-acm-credentials-schedule-20220406171919
  Velero Resources Restore Name:    example-acm-resources-schedule-20220406171920
Events:
  Type    Reason                   Age   From                Message
  ----    ------                   ----  ----                -------
  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-credentials-hive-schedule-20220406155817
  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-credentials-cluster-schedule-20220406155817
  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-credentials-schedule-20220406155817
  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-resources-generic-schedule-20220406155817
  Normal  Prepare to restore:      76m   Restore controller  Cleaning up resources for backup acm-resources-schedule-20220406155817
  Normal  Velero restore created:  74m   Restore controller  example-acm-credentials-schedule-20220406155817
  Normal  Velero restore created:  74m   Restore controller  example-acm-resources-generic-schedule-20220406155817
  Normal  Velero restore created:  74m   Restore controller  example-acm-resources-schedule-20220406155817
  Normal  Velero restore created:  74m   Restore controller  example-acm-credentials-cluster-schedule-20220406155817
  Normal  Velero restore created:  74m   Restore controller  example-acm-credentials-hive-schedule-20220406155817

```