### PR TITLE
backup baremetalhost.metal3.io under activation data

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -56,7 +56,6 @@ var (
 		"core.observatorium.io",
 		"hive.openshift.io",
 		"agent-install.openshift.io",
-		"metal3.io",
 	}
 
 	// exclude resources from these api groups
@@ -104,6 +103,7 @@ var (
 		"clusterpool.hive.openshift.io",
 		"clusterclaim.hive.openshift.io",
 		"clustercurator.cluster.open-cluster-management.io",
+		"baremetalhost.metal3.io",
 	}
 
 	// all backup resources, except secrets, configmaps and managed cluster activation resources


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/21499

Changes: 
- backup only baremetalhost.metal3.io from the metal3.io group
- move it under activation data; it seems that the hosts, once restore, try to power on
- skipped the `Provisioning.metal3.io` CR because one is already created on the restore cluster; unless you restore with the option CleanupAll, the Provisioning is not restored from the backup. I don't think replacing the existing is not going to break something