### PR TITLE
exclude baremetalhost.metal3 from openshift-machine-api ns

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -294,6 +294,11 @@ func setManagedClustersBackupInfo(
 		"local-cluster",
 	)
 
+	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
+		veleroBackupTemplate.ExcludedNamespaces,
+		"openshift-machine-api",
+	)
+
 	for i := range backupManagedClusterResources { // managed clusters required resources, from namespace or cluster level
 		veleroBackupTemplate.IncludedResources = appendUnique(
 			veleroBackupTemplate.IncludedResources,

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -329,6 +329,10 @@ func prepareForBackup(ctx context.Context,
 			LabelSelector: selector,
 		}); err == nil {
 			for s := range metalSecrets.Items {
+				if metalSecrets.Items[s].Namespace == "openshift-machine-api" {
+					// skip secrets from openshift-machine-api ns, these hosts are not backed up
+					continue
+				}
 				updateSecret(ctx, c, metalSecrets.Items[s],
 					backupCredsClusterLabel,
 					"baremetal")


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/21499

Changes:

- backup [baremetalhost.metal3.io](http://baremetalhost.metal3.io/)
- exclude resources from  openshift-machine-api NS
- backup the baremetalhost under the managedclusters ( activation data )