### PR TITLE
Fixes for restore sync

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -171,8 +171,9 @@ func deleteDynamicResource(
 		return false, false
 	}
 
-	if resource.GetLabels() != nil && (resource.GetLabels()["velero.io/exclude-from-backup"] == "true" ||
-		resource.GetLabels()["installer.name"] == "multiclusterhub") {
+	if resource.GetLabels() != nil &&
+		(resource.GetLabels()["velero.io/exclude-from-backup"] == "true" ||
+			resource.GetLabels()["installer.name"] == "multiclusterhub") {
 		// do not cleanup resources with a velero.io/exclude-from-backup=true label, they are not backed up
 		// do not backup subscriptions created by the mch in a separate NS
 		logger.Info(nsSkipMsg)
@@ -496,6 +497,8 @@ func (r *RestoreReconciler) isNewBackupAvailable(
 	switch resourceType {
 	case Resources:
 		latestVeleroRestoreName = restore.Status.VeleroResourcesRestoreName
+	case Credentials:
+		latestVeleroRestoreName = restore.Status.VeleroCredentialsRestoreName
 	}
 	if latestVeleroRestoreName == "" {
 		logger.Info(


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

https://github.com/stolostron/backlog/issues/21478

- Fix sync to check if either new resources backup or new credential backup is available to sync with (used to look for new resources backup only)
- Fix creating Velero restore code not to return error in case the resource already exists (may happen in sync case only)
- Fix cleanup code to skip cleanup if Velero restore already exists and skip ResourcesGeneric cleanup in sync activation case (fix for duplicate cleanups in activation process)

<img width="1656" alt="Screen Shot 2022-04-07 at 1 35 04 PM" src="https://user-images.githubusercontent.com/11761226/162273630-dc934794-0dcb-4417-aa6b-ce8d91899be5.png">
<img width="1582" alt="Screen Shot 2022-04-07 at 2 24 46 PM" src="https://user-images.githubusercontent.com/11761226/162273825-5f0c08c7-a7b1-4226-9454-7e1cf7c74014.png">
