### PR TITLE
backup clustersync with the managed clusters backup

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -94,6 +94,7 @@ var (
 	// resources used to activate the connection between hub and managed clusters - activation resources
 	backupManagedClusterResources = []string{
 		"managedcluster.cluster.open-cluster-management.io", //global
+		"clustersync.hiveinternal.openshift.io",
 		"managedcluster.clusterview.open-cluster-management.io",
 		"klusterletaddonconfig.agent.open-cluster-management.io",
 		"managedclusteraddon.addon.open-cluster-management.io",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/21018

Issue : 

Most of the hive controllers will ignore a CD with no associated ClusterSync object
There's no ClusterSync object initially because it's a hiveinternal CR and the backup has been ignoring those (which should be the right thing theoretically / long-term, but read on...)
The ClusterSync controller refuses to create a ClusterSync object for an unreachable cluster.

Fix: 
Add ClusterSync to the backup data so that hibernating clusters CD are being processed by the hive controllers 