### PR TITLE
skip root policies on cleanup

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -270,8 +270,10 @@ func (r *RestoreReconciler) prepareRestoreForBackup(
 		labelSelector = "velero.io/backup-name,"
 	}
 	switch restoreType {
+	case Resources:
+		labelSelector = labelSelector + "!" + policyRootLabel
 	case ResourcesGeneric:
-		labelSelector = labelSelector + "cluster.open-cluster-management.io/backup"
+		labelSelector = labelSelector + backupCredsClusterLabel
 	case Credentials:
 		labelSelector = labelSelector + backupCredsUserLabel
 	case CredentialsHive:


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

When cleaning up resources before restore, skip resources with label `policy.open-cluster-management.io/root-policy` since those are not backed up

https://github.com/stolostron/backlog/issues/21946