### PR TITLE
cleanup managedclustersets

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -334,6 +334,16 @@ func (r *RestoreReconciler) prepareRestoreForBackup(
 			continue
 		}
 
+		if resources[i] == "managedclusterset.cluster.open-cluster-management.io" &&
+			restoreType == ManagedClusters &&
+			restoreOptions.cleanupType == v1beta1.CleanupTypeRestored {
+			// the "default" managedclusterset is created when acm is installed
+			// which means this is not going to be cleaned up when using the CleanupTypeRestored option
+			// we still want to clean it up though when CleanupTypeRestored is set, to pick up namespace bindings
+			// so we clean up all managedclusterset here, even if they were not created by a previous restore
+			labelSelector = additionalLabels
+		}
+
 		var listOptions = v1.ListOptions{}
 		if labelSelector != "" {
 			listOptions = v1.ListOptions{LabelSelector: labelSelector}


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

related to https://github.com/stolostron/backlog/issues/22236

As we were testing the appset deployment on local cluster, we observed that restored applications were not placed on local cluster, new hub
The appset uses the new placement rule which requires setting the managedcluster set , which in turn is configured to use namespace bindings

The root cause : 
The `default` managedclusterset is created automatically when ACM creates the local-cluster; so this resource exists on the passive hub and was not created by a previous restore
When we restore the data, we use the option `cleanupBeforeRestore: CleanupRestored` which doesn't clean up the `default` managedclusterset ( since it was not created by a restore ); so the default managedclusterset is not updated using the backed up version.
The backed up version in our case had some ns binding which allowed the apps to be deployed 

The fix:
Always clean up all managedclusterset resources, even if the option is `cleanupBeforeRestore: CleanupRestored` ( labelSelector should not use `velero.io/backup-name` for filtering resources )