### PR TITLE
resources with backup label should always be backed up by the generic backup

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -202,6 +202,14 @@ func setResourcesBackupInfo(
 		veleroBackupTemplate.LabelSelector.MatchExpressions,
 		*req,
 	)
+	// exclude resources backed up by the generic resources backup
+	req = &v1.LabelSelectorRequirement{}
+	req.Key = backupCredsClusterLabel
+	req.Operator = "DoesNotExist"
+	veleroBackupTemplate.LabelSelector.MatchExpressions = append(
+		veleroBackupTemplate.LabelSelector.MatchExpressions,
+		*req,
+	)
 
 }
 
@@ -209,17 +217,16 @@ func setResourcesBackupInfo(
 func setGenericResourcesBackupInfo(
 	ctx context.Context,
 	veleroBackupTemplate *veleroapi.BackupSpec,
-	resourcesAlreadyBackedup []string,
 	c client.Client,
 ) {
 
 	var clusterResource bool = true // check global resources
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
-	for i := range resourcesAlreadyBackedup { // exclude resources already backed up resources backup
+	for i := range excludedCRDs { // exclude resources not backed up
 		veleroBackupTemplate.ExcludedResources = appendUnique(
 			veleroBackupTemplate.ExcludedResources,
-			resourcesAlreadyBackedup[i],
+			excludedCRDs[i],
 		)
 	}
 

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -411,7 +411,7 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 			setResourcesBackupInfo(ctx, veleroBackupTemplate, resourcesToBackup,
 				backupSchedule.Namespace, r.Client)
 		case ResourcesGeneric:
-			setGenericResourcesBackupInfo(ctx, veleroBackupTemplate, resourcesToBackup, r.Client)
+			setGenericResourcesBackupInfo(ctx, veleroBackupTemplate, r.Client)
 		case ValidationSchedule:
 			veleroBackupTemplate = setValidationBackupInfo(
 				ctx,

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -869,8 +869,8 @@ var _ = Describe("BackupSchedule controller", func() {
 					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, //secrets are in the creds backup
 						"secret")).Should(BeTrue())
 
-					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, //already in resources backup
-						"placement.cluster.open-cluster-management.io")).Should(BeTrue())
+					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, // resources excluded from backup
+						"clustermanagementaddon.addon.open-cluster-management.io")).Should(BeTrue())
 
 					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, //already in cluster resources backup
 						"klusterletaddonconfig.agent.open-cluster-management.io")).Should(BeTrue())


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

With the exception of the secrets and configmaps which are backed up by the credentials schedule, all other resources having the `cluster.open-cluster-management.io/backup-cluster` should be backed up under the acm-resources-generic-schedule schedule

https://github.com/stolostron/backlog/issues/22478