### PR TITLE
use backupSchedule ttl for MSA validity

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -50,7 +50,7 @@ const (
 	addon_label      = "open-cluster-management.io/addon-name-work"
 
 	manifest_work_name = "addon-" + msa_addon + "-import"
-	validity           = "720h0m0s"
+	defaultTTL         = 720
 	manifestwork       = `{
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "ClusterRoleBinding",
@@ -165,7 +165,7 @@ func prepareImportedClusters(ctx context.Context,
 			// in the managed cluster namespace
 			if len(getMSASecrets(ctx, c, managedCluster.Name)) == 0 {
 
-				tokenValidity := validity
+				tokenValidity := fmt.Sprintf("%vh0m0s", defaultTTL*3)
 				if backupSchedule.Spec.VeleroTTL.Duration != 0 {
 					tokenValidity = fmt.Sprintf("%v", backupSchedule.Spec.VeleroTTL.Duration*3)
 				}

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -370,7 +370,7 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 	}
 
 	// add any missing labels and create any resources required by the backup and restore process
-	r.prepareForBackup(ctx)
+	r.prepareForBackup(ctx, backupSchedule)
 
 	// loop through schedule names to create a Velero schedule per type
 	for _, scheduleKey := range scheduleKeys {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/23876

Changes : 
- if backupschedule ttl time is set, use that for MSA validity; MSA validity = ttl * 3
- if backupschedule not set, use default 720h * 3