### PR TITLE
Velero BackupSpec change in v1.9.0

### DIFF
--- a/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
@@ -409,6 +409,65 @@ spec:
                                   type: string
                                 type: object
                             type: object
+                          orLabelSelectors:
+                            description: OrLabelSelectors is list of metav1.LabelSelector
+                              to filter with when adding individual objects to the
+                              backup. If multiple provided they will be joined by
+                              the OR operator. LabelSelector as well as OrLabelSelectors
+                              cannot co-exist in backup request, only one of them
+                              can be used.
+                            items:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            nullable: true
+                            type: array
                           orderedResources:
                             additionalProperties:
                               type: string
@@ -800,6 +859,65 @@ spec:
                                   type: string
                                 type: object
                             type: object
+                          orLabelSelectors:
+                            description: OrLabelSelectors is list of metav1.LabelSelector
+                              to filter with when adding individual objects to the
+                              backup. If multiple provided they will be joined by
+                              the OR operator. LabelSelector as well as OrLabelSelectors
+                              cannot co-exist in backup request, only one of them
+                              can be used.
+                            items:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            nullable: true
+                            type: array
                           orderedResources:
                             additionalProperties:
                               type: string
@@ -1191,6 +1309,65 @@ spec:
                                   type: string
                                 type: object
                             type: object
+                          orLabelSelectors:
+                            description: OrLabelSelectors is list of metav1.LabelSelector
+                              to filter with when adding individual objects to the
+                              backup. If multiple provided they will be joined by
+                              the OR operator. LabelSelector as well as OrLabelSelectors
+                              cannot co-exist in backup request, only one of them
+                              can be used.
+                            items:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            nullable: true
+                            type: array
                           orderedResources:
                             additionalProperties:
                               type: string


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

We upgraded our Velero dependency from github.com/vmware-tanzu/velero v1.7.1 to github.com/vmware-tanzu/velero v1.9.0 in https://github.com/stolostron/cluster-backup-operator/pull/270, this includes an API change related to BackupSpec which defines the specification for a Velero backup. This change affects our BackupSchedule CRD.