### PR TITLE
create pair MSA account

### DIFF
--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -206,6 +206,10 @@ var _ = Describe("BackupSchedule controller", func() {
 					Labels: map[string]string{
 						"authentication.open-cluster-management.io/is-managed-serviceaccount": "true",
 					},
+					Annotations: map[string]string{
+						"expirationTimestamp":  "2024-08-05T15:25:34Z",
+						"lastRefreshTimestamp": "2022-07-26T15:25:34Z",
+					},
 				},
 			},
 			{


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Changes:
- annotate MSA token with token `lastRefreshTimestamp` information. This is useful because the token might have been created  after the MSA was created ( cluster is down at the time the MSA is created ) ; it is useful when the token refresh doesn't match the expected expiry time ( same scenario, the token should expire but since the cluster is not reachable the recycle cannot happen when the token is set to expire )
- created a new MSA pair token when the initial token validity had passed half the expiration time; the logic : the initial MSA token is set to expire 2*backupTTL; let's say backupTTL=12h then token is valid for 24h; so if a backup is created 14h after the MSA token (14h > 24h/2 ), this backup will pick up the token, which is valid at the time of the backup creation, but it will be available 14h+12h=26h after the token was created; so the backup is still valid 4h more than the token validity. To cover this case, we create an extra MSA-pair, which creates a 12h after the initial token creation ( so after initial token half way lifecycle ). The backup in the sample above will have a life span of 26h after the initial token was created. Which means, at hour 25 let's say, the backup contains an initial token which is invalid; but it also contains the pair token, created at 12h ( so before the backup was created ), and is still valid
- added test coverage