### PR TITLE
test coverage for cleanup option

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -805,31 +805,20 @@ func getVeleroBackupName(
 	return "", nil, fmt.Errorf("cannot find %s Velero Backup: %v", backupName, err)
 }
 
-// returns true if the restore should run the cleanup first
-func shouldRunCleanup(
-	ctx context.Context,
+func isValidCleanupOption(
 	acmRestore *v1beta1.Restore,
-) bool {
+) string {
 
 	if ok := findValue([]string{v1beta1.CleanupTypeAll,
 		v1beta1.CleanupTypeNone,
 		v1beta1.CleanupTypeRestored},
 		string(acmRestore.Spec.CleanupBeforeRestore)); !ok {
 
-		restoreLogger := log.FromContext(ctx)
-
 		msg := "invalid CleanupBeforeRestore value : " +
 			string(acmRestore.Spec.CleanupBeforeRestore)
-		acmRestore.Status.LastMessage = msg
-		restoreLogger.Error(fmt.Errorf(msg), "error")
-		return false
+		return msg
 
 	}
 
-	// clean up resources only if requested
-	if acmRestore.Spec.CleanupBeforeRestore == v1beta1.CleanupTypeNone {
-		return false
-	}
-
-	return true
+	return ""
 }

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -804,3 +804,32 @@ func getVeleroBackupName(
 	}
 	return "", nil, fmt.Errorf("cannot find %s Velero Backup: %v", backupName, err)
 }
+
+// returns true if the restore should run the cleanup first
+func shouldRunCleanup(
+	ctx context.Context,
+	acmRestore v1beta1.Restore,
+) bool {
+
+	if ok := findValue([]string{v1beta1.CleanupTypeAll,
+		v1beta1.CleanupTypeNone,
+		v1beta1.CleanupTypeRestored},
+		string(acmRestore.Spec.CleanupBeforeRestore)); !ok {
+
+		restoreLogger := log.FromContext(ctx)
+
+		msg := "invalid CleanupBeforeRestore value : " +
+			string(acmRestore.Spec.CleanupBeforeRestore)
+		acmRestore.Status.LastMessage = msg
+		restoreLogger.Error(fmt.Errorf(msg), "error")
+		return false
+
+	}
+
+	// clean up resources only if requested
+	if acmRestore.Spec.CleanupBeforeRestore == v1beta1.CleanupTypeNone {
+		return false
+	}
+
+	return true
+}

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -808,7 +808,7 @@ func getVeleroBackupName(
 // returns true if the restore should run the cleanup first
 func shouldRunCleanup(
 	ctx context.Context,
-	acmRestore v1beta1.Restore,
+	acmRestore *v1beta1.Restore,
 ) bool {
 
 	if ok := findValue([]string{v1beta1.CleanupTypeAll,

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -425,8 +425,6 @@ func (r *RestoreReconciler) initVeleroRestores(
 	}
 
 	// clean up resources only if requested
-	// continue with the restore even if the prepare for restore returned some errors
-	// we don't know how much was cleaned up prior to the error so don't abort the action now
 	r.prepareForRestore(ctx, *restore, veleroRestoresToCreate, backupsForVeleroRestores)
 	newVeleroRestoreCreated := false
 

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -637,7 +637,7 @@ func (r *RestoreReconciler) prepareForRestore(
 	backupsForVeleroRestores map[ResourceType]*veleroapi.Backup,
 ) {
 
-	if shouldRun := shouldRunCleanup(ctx, acmRestore); shouldRun {
+	if shouldRun := shouldRunCleanup(ctx, &acmRestore); shouldRun {
 
 		deletePolicy := metav1.DeletePropagationForeground
 		delOptions := metav1.DeleteOptions{

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -410,13 +410,9 @@ func (r *RestoreReconciler) initVeleroRestores(
 	}
 
 	// clean up resources only if requested
-	if err := r.prepareForRestore(ctx, *restore, veleroRestoresToCreate,
-		backupsForVeleroRestores); err != nil {
-		// continue with the restore even if the prepare for restore returned some errors
-		// we don't know how much was cleaned up prior to the error so don't abort the action now
-		restoreLogger.Error(err, "Prepare for restore returned error")
-	}
-
+	// continue with the restore even if the prepare for restore returned some errors
+	// we don't know how much was cleaned up prior to the error so don't abort the action now
+	r.prepareForRestore(ctx, *restore, veleroRestoresToCreate, backupsForVeleroRestores)
 	newVeleroRestoreCreated := false
 
 	// now create the restore resources and start the actual restore
@@ -639,90 +635,74 @@ func (r *RestoreReconciler) prepareForRestore(
 	acmRestore v1beta1.Restore,
 	veleroRestoresToCreate map[ResourceType]*veleroapi.Restore,
 	backupsForVeleroRestores map[ResourceType]*veleroapi.Backup,
-) error {
+) {
 
-	if ok := findValue([]string{v1beta1.CleanupTypeAll,
-		v1beta1.CleanupTypeNone,
-		v1beta1.CleanupTypeRestored},
-		string(acmRestore.Spec.CleanupBeforeRestore)); !ok {
+	if shouldRun := shouldRunCleanup(ctx, acmRestore); shouldRun {
 
-		msg := "invalid CleanupBeforeRestore value : " +
-			string(acmRestore.Spec.CleanupBeforeRestore)
-		acmRestore.Status.LastMessage = msg
-		return fmt.Errorf(msg)
-	}
-
-	// clean up resources only if requested
-	if acmRestore.Spec.CleanupBeforeRestore == v1beta1.CleanupTypeNone {
-		return nil
-	}
-
-	deletePolicy := metav1.DeletePropagationForeground
-	delOptions := metav1.DeleteOptions{
-		PropagationPolicy: &deletePolicy,
-	}
-
-	reconcileArgs := DynamicStruct{
-		dc:     r.DiscoveryClient,
-		dyn:    r.DynamicClient,
-		mapper: r.RESTMapper,
-	}
-
-	restoreOptions := RestoreOptions{
-		dynamicArgs:   reconcileArgs,
-		cleanupType:   acmRestore.Spec.CleanupBeforeRestore,
-		deleteOptions: delOptions,
-	}
-
-	for key := range veleroRestoresToCreate {
-
-		veleroRestore := veleroapi.Restore{}
-		err := r.Get(
-			ctx,
-			types.NamespacedName{
-				Name:      veleroRestoresToCreate[key].Name,
-				Namespace: veleroRestoresToCreate[key].Namespace,
-			},
-			&veleroRestore,
-		)
-		if err == nil {
-			// restore with this name already exists
-			// so ignore the cleanup because the restore won't be created afterwards
-			continue
+		deletePolicy := metav1.DeletePropagationForeground
+		delOptions := metav1.DeleteOptions{
+			PropagationPolicy: &deletePolicy,
 		}
 
-		additionalLabel := ""
-		if key == ManagedClusters && veleroRestoresToCreate[ResourcesGeneric] == nil &&
-			!acmRestore.Spec.SyncRestoreWithNewBackups {
-			// process here generic resources with an activation label
-			// since generic resources are not restored
-			additionalLabel = "cluster.open-cluster-management.io/backup in (cluster-activation)"
+		reconcileArgs := DynamicStruct{
+			dc:     r.DiscoveryClient,
+			dyn:    r.DynamicClient,
+			mapper: r.RESTMapper,
+		}
+
+		restoreOptions := RestoreOptions{
+			dynamicArgs:   reconcileArgs,
+			cleanupType:   acmRestore.Spec.CleanupBeforeRestore,
+			deleteOptions: delOptions,
+		}
+
+		for key := range veleroRestoresToCreate {
+
+			veleroRestore := veleroapi.Restore{}
+			err := r.Get(
+				ctx,
+				types.NamespacedName{
+					Name:      veleroRestoresToCreate[key].Name,
+					Namespace: veleroRestoresToCreate[key].Namespace,
+				},
+				&veleroRestore,
+			)
+			if err == nil {
+				// restore with this name already exists
+				// so ignore the cleanup because the restore won't be created afterwards
+				continue
+			}
+
+			additionalLabel := ""
+			if key == ManagedClusters && veleroRestoresToCreate[ResourcesGeneric] == nil &&
+				!acmRestore.Spec.SyncRestoreWithNewBackups {
+				// process here generic resources with an activation label
+				// since generic resources are not restored
+				additionalLabel = "cluster.open-cluster-management.io/backup in (cluster-activation)"
+				r.prepareRestoreForBackup(
+					ctx,
+					&acmRestore,
+					restoreOptions,
+					ResourcesGeneric,
+					backupsForVeleroRestores[key],
+					additionalLabel,
+				)
+			}
+
+			if key == ManagedClusters && veleroRestoresToCreate[Resources] != nil {
+				// managed clusters restore are being processed with resources
+				// so ignore this call here
+				continue
+			}
+
 			r.prepareRestoreForBackup(
 				ctx,
 				&acmRestore,
 				restoreOptions,
-				ResourcesGeneric,
+				key,
 				backupsForVeleroRestores[key],
 				additionalLabel,
 			)
 		}
-
-		if key == ManagedClusters && veleroRestoresToCreate[Resources] != nil {
-			// managed clusters restore are being processed with resources
-			// so ignore this call here
-			continue
-		}
-
-		r.prepareRestoreForBackup(
-			ctx,
-			&acmRestore,
-			restoreOptions,
-			key,
-			backupsForVeleroRestores[key],
-			additionalLabel,
-		)
-
 	}
-
-	return nil
 }

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1621,9 +1621,8 @@ func Test_isOtherRestoresRunning(t *testing.T) {
 	}
 }
 
-func Test_shouldRunCleanup(t *testing.T) {
+func Test_isValidCleanupOption(t *testing.T) {
 	type args struct {
-		ctx     context.Context
 		restore *v1beta1.Restore
 	}
 	tests := []struct {
@@ -1632,29 +1631,8 @@ func Test_shouldRunCleanup(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "restore has no cleanup option",
-			args: args{
-				ctx: context.Background(),
-				restore: &v1beta1.Restore{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "cluster.open-cluster-management.io/v1beta1",
-						Kind:       "Restore",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-name",
-						Namespace: "ns",
-					},
-					Spec: v1beta1.RestoreSpec{
-						CleanupBeforeRestore: v1beta1.CleanupTypeNone,
-					},
-				},
-			},
-			want: false,
-		},
-		{
 			name: "restore has invalid cleanup option",
 			args: args{
-				ctx: context.Background(),
 				restore: &v1beta1.Restore{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "cluster.open-cluster-management.io/v1beta1",
@@ -1674,7 +1652,6 @@ func Test_shouldRunCleanup(t *testing.T) {
 		{
 			name: "restore has cleanup option, should cleanup ",
 			args: args{
-				ctx: context.Background(),
 				restore: &v1beta1.Restore{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "cluster.open-cluster-management.io/v1beta1",
@@ -1694,8 +1671,8 @@ func Test_shouldRunCleanup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldRunCleanup(tt.args.ctx, tt.args.restore); got != tt.want {
-				t.Errorf("isOtherRestoresRunning() = %v, want %v", got, tt.want)
+			if got := isValidCleanupOption(tt.args.restore); len(got) == 0 != tt.want {
+				t.Errorf("isValidCleanupOption() = %v, want len of string is empty %v", len(got) == 0, tt.want)
 			}
 		})
 	}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1620,3 +1620,83 @@ func Test_isOtherRestoresRunning(t *testing.T) {
 		})
 	}
 }
+
+func Test_shouldRunCleanup(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		restore v1beta1.Restore
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "restore has no cleanup option",
+			args: args{
+				ctx: context.Background(),
+				restore: v1beta1.Restore{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cluster.open-cluster-management.io/v1beta1",
+						Kind:       "Restore",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-name",
+						Namespace: "ns",
+					},
+					Spec: v1beta1.RestoreSpec{
+						CleanupBeforeRestore: v1beta1.CleanupTypeNone,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "restore has invalid cleanup option",
+			args: args{
+				ctx: context.Background(),
+				restore: v1beta1.Restore{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cluster.open-cluster-management.io/v1beta1",
+						Kind:       "Restore",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-name",
+						Namespace: "ns",
+					},
+					Spec: v1beta1.RestoreSpec{
+						CleanupBeforeRestore: "someWrongValue",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "restore has cleanup option, should cleanup ",
+			args: args{
+				ctx: context.Background(),
+				restore: v1beta1.Restore{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cluster.open-cluster-management.io/v1beta1",
+						Kind:       "Restore",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-name",
+						Namespace: "ns",
+					},
+					Spec: v1beta1.RestoreSpec{
+						CleanupBeforeRestore: v1beta1.CleanupTypeAll,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRunCleanup(tt.args.ctx, tt.args.restore); got != tt.want {
+				t.Errorf("isOtherRestoresRunning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1624,7 +1624,7 @@ func Test_isOtherRestoresRunning(t *testing.T) {
 func Test_shouldRunCleanup(t *testing.T) {
 	type args struct {
 		ctx     context.Context
-		restore v1beta1.Restore
+		restore *v1beta1.Restore
 	}
 	tests := []struct {
 		name string
@@ -1635,7 +1635,7 @@ func Test_shouldRunCleanup(t *testing.T) {
 			name: "restore has no cleanup option",
 			args: args{
 				ctx: context.Background(),
-				restore: v1beta1.Restore{
+				restore: &v1beta1.Restore{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "cluster.open-cluster-management.io/v1beta1",
 						Kind:       "Restore",
@@ -1655,7 +1655,7 @@ func Test_shouldRunCleanup(t *testing.T) {
 			name: "restore has invalid cleanup option",
 			args: args{
 				ctx: context.Background(),
-				restore: v1beta1.Restore{
+				restore: &v1beta1.Restore{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "cluster.open-cluster-management.io/v1beta1",
 						Kind:       "Restore",
@@ -1675,7 +1675,7 @@ func Test_shouldRunCleanup(t *testing.T) {
 			name: "restore has cleanup option, should cleanup ",
 			args: args{
 				ctx: context.Background(),
-				restore: v1beta1.Restore{
+				restore: &v1beta1.Restore{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "cluster.open-cluster-management.io/v1beta1",
 						Kind:       "Restore",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

- Fixed reporting of invalid cleanup value, it shows now
- restore should not execute if the cleanup option is invalid

```
kind: Restore
metadata:
  name: example2
  namespace: open-cluster-management-backup
spec:
  cleanupBeforeRestore: aaaaaa
  veleroCredentialsBackupName: latest
  veleroManagedClustersBackupName: latest
  veleroResourcesBackupName: latest
status:
  lastMessage: 'invalid CleanupBeforeRestore value : aaaaaa'
  phase: FinishedWithErrors
```
