### PR TITLE
create backups when new schedule is created

### DIFF
--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -328,8 +328,7 @@ func createInitialBackupForSchedule(
 	scheduleLogger := log.FromContext(ctx)
 	veleroBackup := &veleroapi.Backup{}
 
-	if !backupSchedue.Spec.NoBackupOnStart {
-		//replace !backupSchedue.Spec.NoBackupOnStart AFTER moving to OADP 1.1
+	if backupSchedue.Spec.NoBackupOnStart {
 		// do not generate backups, exit now
 		scheduleLogger.Info("skip backup creation, backupSchedue.Spec.NoBackupOnStart set to true")
 		return veleroBackup, nil


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/25596

Changes:
- when new schedules are created, generate new backups; this is the default behavior since we just moved to install oadp 1.1 in 2.7; which no longer creates backups on schedule creation
- you can disable the backup creation by setting `Spec.NoBackupOnStart=true` on the BackupSchedule CR 