### PR TITLE
restore uses old hive cred backup whith oadp 1.1 orSelector

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -857,8 +857,6 @@ func retrieveRestoreDetails(
 	map[ResourceType]*veleroapi.Backup,
 	error) {
 
-	restoreLogger := log.FromContext(ctx)
-
 	restoreLength := len(veleroBackupNames) - 1 // ignore validation backup
 	if restoreOnlyManagedClusters {
 		restoreLength = 2 // will get only managed clusters and generic resources
@@ -879,6 +877,23 @@ func retrieveRestoreDetails(
 	sort.Slice(restoreKeys, func(i, j int) bool {
 		return restoreKeys[i] > restoreKeys[j]
 	})
+
+	return processRetrieveRestoreDetails(ctx, c, s, acmRestore, restoreKeys)
+
+}
+
+func processRetrieveRestoreDetails(
+	ctx context.Context,
+	c client.Client,
+	s *runtime.Scheme,
+	acmRestore *v1beta1.Restore,
+	restoreKeys []ResourceType,
+) (map[ResourceType]*veleroapi.Restore,
+	map[ResourceType]*veleroapi.Backup,
+	error) {
+
+	restoreLogger := log.FromContext(ctx)
+
 	veleroRestoresToCreate := make(map[ResourceType]*veleroapi.Restore, len(restoreKeys))
 	backupsForVeleroRestores := make(map[ResourceType]*veleroapi.Backup, len(restoreKeys))
 

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -838,6 +838,10 @@ func Test_postRestoreActivation(t *testing.T) {
 						object,
 				},
 				secrets: []corev1.Secret{
+					*createSecret("auto-import-ignore-this-one", "managed1",
+						nil, map[string]string{
+							"lastRefreshTimestamp": fourHoursAgo,
+						}, nil),
 					*createSecret("auto-import", "local-cluster",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -887,11 +887,38 @@ func Test_getVeleroBackupName(t *testing.T) {
 	veleroNamespaceName := "backup-ns"
 	veleroNamespace := *createNamespace(veleroNamespaceName)
 
-	backup := *createBackup("acm-credentials-cluster-schedule-20220922170041", veleroNamespaceName).
+	backup := *createBackup("acm-credentials-schedule-20220922170041", veleroNamespaceName).
 		labels(map[string]string{
 			BackupVeleroLabel:          "aa",
 			BackupScheduleClusterLabel: "abcd",
 		}).
+		phase(veleroapi.BackupPhaseCompleted).
+		errors(0).object
+
+	backupClsNoMatch := *createBackup("acm-credentials-cluster-schedule-20220922170039", veleroNamespaceName).
+		labels(map[string]string{
+			BackupVeleroLabel:          "aa",
+			BackupScheduleClusterLabel: "abcd",
+		}).
+		phase(veleroapi.BackupPhaseCompleted).
+		errors(0).object
+
+	backupClsExactTime := *createBackup("acm-credentials-cluster-schedule-20220922170041", veleroNamespaceName).
+		labels(map[string]string{
+			BackupVeleroLabel:          "aa",
+			BackupScheduleClusterLabel: "abcd",
+		}).
+		phase(veleroapi.BackupPhaseCompleted).
+		errors(0).object
+
+	backupTime, _ := time.Parse(time.RFC3339, "2022-09-22T17:00:15Z")
+
+	backupClsExactWithin30s := *createBackup("acm-credentials-cluster-schedule-202209221745", veleroNamespaceName).
+		labels(map[string]string{
+			BackupVeleroLabel:          "aa",
+			BackupScheduleClusterLabel: "abcd",
+		}).
+		startTimestamp(metav1.NewTime(backupTime)).
 		phase(veleroapi.BackupPhaseCompleted).
 		errors(0).object
 
@@ -944,7 +971,29 @@ func Test_getVeleroBackupName(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "found backup item ",
+			name: "found backup item for credentials",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				resourceType:     Credentials,
+				backupName:       latestBackupStr,
+				restoreNamespace: veleroNamespaceName,
+			},
+			want: backup.Name,
+		},
+		{
+			name: "NOT found backup item for credentials hive",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				resourceType:     CredentialsHive,
+				backupName:       latestBackupStr,
+				restoreNamespace: veleroNamespaceName,
+			},
+			want: "",
+		},
+		{
+			name: "found backup item for credentials cluster NOT found no exact match on timestamp and not within 30s",
 			args: args{
 				ctx:              context.Background(),
 				c:                k8sClient1,
@@ -952,7 +1001,29 @@ func Test_getVeleroBackupName(t *testing.T) {
 				backupName:       latestBackupStr,
 				restoreNamespace: veleroNamespaceName,
 			},
-			want: backup.Name,
+			want: "",
+		},
+		{
+			name: "found backup item for credentials cluster when exact match on timestamp",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				resourceType:     CredentialsCluster,
+				backupName:       latestBackupStr,
+				restoreNamespace: veleroNamespaceName,
+			},
+			want: backupClsExactTime.Name,
+		},
+		{
+			name: "found backup item for credentials cluster when NOT exact match on timestamp but withn 30s",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				resourceType:     CredentialsCluster,
+				backupName:       latestBackupStr,
+				restoreNamespace: veleroNamespaceName,
+			},
+			want: backupClsExactWithin30s.Name,
 		},
 	}
 
@@ -964,10 +1035,20 @@ func Test_getVeleroBackupName(t *testing.T) {
 		if index == 2 {
 			k8sClient1.Create(context.Background(), &veleroNamespace)
 			k8sClient1.Create(context.Background(), &backup)
+			k8sClient1.Create(context.Background(), &backupClsNoMatch)
+		}
+		if index == len(tests)-2 {
+			k8sClient1.Create(context.Background(), &backupClsExactTime)
+		}
+		if index == len(tests)-1 {
+			k8sClient1.Create(context.Background(), &backupClsExactWithin30s)
+			k8sClient1.Delete(context.Background(), &backupClsExactTime)
 		}
 		t.Run(tt.name, func(t *testing.T) {
+			veleroBackups := &veleroapi.BackupList{}
+			tt.args.c.List(tt.args.ctx, veleroBackups, client.InNamespace(veleroNamespace.Name))
 			if name, _, _ := getVeleroBackupName(tt.args.ctx, tt.args.c,
-				tt.args.restoreNamespace, tt.args.resourceType, tt.args.backupName); name != tt.want {
+				tt.args.restoreNamespace, tt.args.resourceType, tt.args.backupName, veleroBackups); name != tt.want {
 				t.Errorf("getVeleroBackupName() returns = %v, want %v", name, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/25596

related to https://github.com/stolostron/cluster-backup-operator/pull/313

If the backup doesn't create the hive and cluster creds backup ( with oadp 1.1 we group them in one backup ), restore looks for hive and cluster creds backup and finds ones that should not match the current backup

Change : look for those backups, for backward compatibility, but get the backups that matches the `acm-credentials-schedule` by start time and timestamp. 