### PR TITLE
swap backups to have resources run last

### DIFF
--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -291,8 +291,9 @@ func isRestoreRunning(
 	ctx context.Context,
 	c client.Client,
 	backupSchedule *v1beta1.BackupSchedule,
-) (string, error) {
+) string {
 
+	scheduleLogger := log.FromContext(ctx)
 	restoreName := ""
 
 	restoreList := v1beta1.RestoreList{}
@@ -301,11 +302,12 @@ func isRestoreRunning(
 		&restoreList,
 		client.InNamespace(backupSchedule.Namespace),
 	); err != nil {
-		return restoreName, err
+		scheduleLogger.Error(err, "cannot list resource")
+		return restoreName
 	}
 
 	if len(restoreList.Items) == 0 {
-		return restoreName, nil
+		return restoreName
 	}
 
 	for i := range restoreList.Items {
@@ -316,7 +318,7 @@ func isRestoreRunning(
 			break
 		}
 	}
-	return restoreName, nil
+	return restoreName
 }
 
 func createInitialBackupForSchedule(

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -265,11 +265,7 @@ func (r *BackupScheduleReconciler) isValidateConfiguration(
 	}
 
 	// don't create schedule if an active restore exists
-	restoreName, err := isRestoreRunning(ctx, r.Client, backupSchedule)
-	if err != nil {
-		return ctrl.Result{}, validConfiguration, err
-	}
-	if restoreName != "" {
+	if restoreName := isRestoreRunning(ctx, r.Client, backupSchedule); restoreName != "" {
 		msg := "Restore resource " + restoreName + " is currently active, " +
 			"verify that any active restores are removed."
 		return createFailedValidationResponse(ctx, r.Client, backupSchedule,
@@ -349,9 +345,9 @@ func (r *BackupScheduleReconciler) initVeleroSchedules(
 	sort.Sort(SortResourceType(scheduleKeys))
 	// swap the last two items to put the resources last, after the resourcesGeneric
 	swapF := reflect.Swapper(scheduleKeys)
-	if len(scheduleKeys) > 5 {
+	if len(scheduleKeys) > 3 {
 		// swap resources and resourcesGeneric, so resources is the last backup to be created
-		swapF(4, 5)
+		swapF(2, 3)
 	}
 
 	// add any missing labels and create any resources required by the backup and restore process

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -398,7 +398,7 @@ func Test_isRestoreRunning(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := isRestoreRunning(tt.args.ctx, tt.args.c,
+			if got := isRestoreRunning(tt.args.ctx, tt.args.c,
 				tt.args.backupSchedule); got != tt.want {
 				t.Errorf("isRestoreRunning() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/25596
related to https://github.com/stolostron/cluster-backup-operator/pull/313

With the number of backups reduced to 5, the swap should be updated