### PR TITLE
process delta for restore clusters

### DIFF
--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -2172,7 +2172,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 				tt.args.veleroBackup)
 		})
 
-		// managed cluster
+		// managed cluster group
 		groupKind := schema.GroupKind{
 			Group: clsGVK.Group,
 			Kind:  clsGVK.Kind,


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/25596

Clean up managed cluster backup resources post restore; remove resources created by a previous restore which are no longer part of the latest restored backup
If managedClusters are not restored, clean up generic resources but with a label value not equal with cluster-activation
If managedClusters are restored, clean up all generic resources