### PR TITLE
fix CRD not picked up after pod is running

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -14,5 +14,5 @@ build-prow:
 export HOME = /tmp/home
 unit-tests:
 	mkdir $(HOME)
-	GOFLAGS="" go test -timeout 300s -v -short ./controllers
+	GOFLAGS="" go test -timeout 600s -v -short ./controllers
 	

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -31,7 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -96,7 +98,11 @@ func (r *BackupScheduleReconciler) prepareForBackup(
 		Group: msa_group,
 		Kind:  msa_kind,
 	}
-	msaMapping, err := r.RESTMapper.RESTMapping(msaKind, "")
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(
+		memory.NewMemCacheClient(r.DiscoveryClient),
+	)
+
+	msaMapping, err := mapper.RESTMapping(msaKind, "")
 	var dr dynamic.NamespaceableResourceInterface
 	if err == nil {
 		logger.Info("ManagedServiceAccounts is enabled, generate MSA accounts if needed")

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +54,8 @@ const (
 )
 
 type DynamicStruct struct {
-	dc     discovery.DiscoveryInterface
-	dyn    dynamic.Interface
-	mapper *restmapper.DeferredDiscoveryRESTMapper
+	dc  discovery.DiscoveryInterface
+	dyn dynamic.Interface
 }
 
 type RestoreOptions struct {
@@ -71,7 +69,6 @@ type RestoreReconciler struct {
 	KubeClient      kubernetes.Interface
 	DiscoveryClient discovery.DiscoveryInterface
 	DynamicClient   dynamic.Interface
-	RESTMapper      *restmapper.DeferredDiscoveryRESTMapper
 	Scheme          *runtime.Scheme
 	Recorder        record.EventRecorder
 }
@@ -212,9 +209,8 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		reconcileArgs := DynamicStruct{
-			dc:     r.DiscoveryClient,
-			dyn:    r.DynamicClient,
-			mapper: r.RESTMapper,
+			dc:  r.DiscoveryClient,
+			dyn: r.DynamicClient,
 		}
 
 		restoreOptions := RestoreOptions{

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -384,7 +384,7 @@ func verifyMSAOption(
 		if _, err := m.RESTMapping(msaKind, ""); err != nil {
 			scheduleLogger.Error(err, "MSA CRD not found")
 			return createFailedValidationResponse(ctx, c, backupSchedule,
-				msg, false)
+				msg, true) // want to reque, if CRD is installed after
 		}
 	}
 

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -563,6 +563,8 @@ var _ = Describe("BackupSchedule controller", func() {
 			// when the clusterID is checked, it is going to be (unkonwn) - since we have no cluster resource on test
 			// and the previous schedules had used abcd as clusterId
 			time.Sleep(time.Second * 7)
+			// get the schedule again
+			k8sClient.Get(ctx, backupLookupKey, &createdBackupSchedule)
 			createdBackupSchedule.Spec.VeleroTTL = metav1.Duration{Duration: time.Hour * 50}
 			Eventually(func() bool {
 				err := k8sClient.Update(
@@ -755,22 +757,6 @@ var _ = Describe("BackupSchedule controller", func() {
 			}, timeout, interval).Should(BeTrue())
 			Expect(len(veleroScheduleList.Items)).To(BeNumerically("==", len(veleroScheduleNames)))
 
-			// delete existing velero schedule
-			Eventually(func() bool {
-				scheduleObj := veleroScheduleList.Items[0].DeepCopy()
-				err := k8sClient.Delete(ctx, scheduleObj)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-
-			// count velero schedules, should still be 5
-			veleroScheduleList = veleroapi.ScheduleList{}
-			Eventually(func() int {
-				err := k8sClient.List(ctx, &veleroScheduleList, &client.ListOptions{})
-				if err != nil {
-					return 0
-				}
-				return len(veleroScheduleList.Items)
-			}, timeout, interval).Should(BeNumerically("==", len(veleroScheduleNames)))
 			for i := range veleroScheduleList.Items {
 
 				veleroSchedule := veleroScheduleList.Items[i]

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -736,7 +736,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 				mapping:        fakemapper,
 				backupSchedule: &sch_msa,
 			},
-			want: true,
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -40,14 +40,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"k8s.io/client-go/discovery"
 	discoveryclient "k8s.io/client-go/discovery"
-	"k8s.io/client-go/discovery/cached/memory"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 )
 
 func initBackupSchedule(cronString string) *v1beta1.BackupSchedule {
@@ -703,15 +702,12 @@ func Test_verifyMSAOptione(t *testing.T) {
 	fakeDiscovery := discoveryclient.NewDiscoveryClientForConfigOrDie(
 		&restclient.Config{Host: server.URL},
 	)
-	fakemapper := restmapper.NewDeferredDiscoveryRESTMapper(
-		memory.NewMemCacheClient(fakeDiscovery),
-	)
 
 	type args struct {
 		ctx            context.Context
 		c              client.Client
 		backupSchedule *v1beta1.BackupSchedule
-		mapping        *restmapper.DeferredDiscoveryRESTMapper
+		dc             discovery.DiscoveryInterface
 	}
 	tests := []struct {
 		name string
@@ -723,7 +719,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 			args: args{
 				ctx:            context.Background(),
 				c:              k8sClient1,
-				mapping:        fakemapper,
+				dc:             fakeDiscovery,
 				backupSchedule: &sch,
 			},
 			want: true,
@@ -733,7 +729,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 			args: args{
 				ctx:            context.Background(),
 				c:              k8sClient1,
-				mapping:        fakemapper,
+				dc:             fakeDiscovery,
 				backupSchedule: &sch_msa,
 			},
 			want: false,
@@ -744,7 +740,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 			if _, got, _ := verifyMSAOption(tt.args.ctx,
 				tt.args.c,
 				tt.args.backupSchedule,
-				tt.args.mapping); got != tt.want {
+				tt.args.dc); got != tt.want {
 				t.Errorf("verifyMSAOption() = %v, want %v", got,
 					tt.want)
 			}

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -736,7 +736,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 				mapping:        fakemapper,
 				backupSchedule: &sch_msa,
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -31,10 +31,8 @@ import (
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	certsv1 "k8s.io/api/certificates/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/discovery/cached/memory"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/restmapper"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -434,10 +432,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(mgr).NotTo(BeNil())
 
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(
-		memory.NewMemCacheClient(fakeDiscovery),
-	)
-
 	res_channel_default := &unstructured.Unstructured{}
 	res_channel_default.SetUnstructuredContent(map[string]interface{}{
 		"apiVersion": "apps.open-cluster-management.io/v1beta1",
@@ -637,7 +631,6 @@ var _ = BeforeSuite(func() {
 		Scheme:          mgr.GetScheme(),
 		DiscoveryClient: fakeDiscovery,
 		DynamicClient:   dynR,
-		RESTMapper:      mapper,
 		Recorder:        mgr.GetEventRecorderFor("restore reconciler"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
@@ -647,7 +640,6 @@ var _ = BeforeSuite(func() {
 		Scheme:          mgr.GetScheme(),
 		DiscoveryClient: fakeDiscovery,
 		DynamicClient:   dyn,
-		RESTMapper:      mapper,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -23,11 +23,9 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"go.uber.org/zap/zapcore"
-	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/restmapper"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -131,15 +129,11 @@ func main() {
 		setupLog.Error(err, "unable to set up dynamic client")
 		os.Exit(1)
 	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(
-		memory.NewMemCacheClient(dc),
-	)
 
 	if err = (&controllers.BackupScheduleReconciler{
 		Client:          mgr.GetClient(),
 		DiscoveryClient: dc,
 		DynamicClient:   dyn,
-		RESTMapper:      mapper,
 		Scheme:          mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Schedule controller")
@@ -155,7 +149,6 @@ func main() {
 		KubeClient:      kubeClient,
 		DiscoveryClient: dc,
 		DynamicClient:   dyn,
-		RESTMapper:      mapper,
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("Restore controller"),
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/24206#issuecomment-1279479335

Changes:
- reconcile after backupschedule failed validation due to the MSA option being invalid
- recreate the mapper on each reconcile
- remove mapper for restore reconciler, create one from discoveryInterface