### PR TITLE
don't backup MSA and clean up secret on new backup

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -50,6 +50,8 @@ var (
 	BackupNameVeleroLabel string = "velero.io/backup-name"
 
 	ClusterActivationLabel string = "cluster-activation"
+
+	ExcludeBackupLabel string = "velero.io/exclude-from-backup"
 )
 var (
 	// include resources from these api groups

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -361,14 +361,14 @@ func createMSA(
 
 	if generateMSA {
 		// delete any secret with the same name as the MSA
-		msa_secret := corev1.Secret{}
+		msaSecret := corev1.Secret{}
 		if err := c.Get(ctx, types.NamespacedName{
 			Name:      name,
 			Namespace: managedClusterName,
-		}, &msa_secret); err == nil {
+		}, &msaSecret); err == nil {
 			// found an MSA secret with the same name as the MSA; delete it, it will be recreated by the MSA
 			logger.Info("Deleting MSA secret %s in ns %s", name, managedClusterName)
-			if err := c.Delete(ctx, &msa_secret); err == nil {
+			if err := c.Delete(ctx, &msaSecret); err == nil {
 				logger.Info("Deleted MSA secret %s in ns %s", name, managedClusterName)
 			}
 		}

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -595,7 +595,7 @@ func deleteDynamicResource(
 	}
 
 	if resource.GetLabels() != nil &&
-		(resource.GetLabels()["velero.io/exclude-from-backup"] == "true" ||
+		(resource.GetLabels()[ExcludeBackupLabel] == "true" ||
 			resource.GetLabels()["installer.name"] == "multiclusterhub") {
 		// do not cleanup resources with a velero.io/exclude-from-backup=true label, they are not backed up
 		// do not backup subscriptions created by the mch in a separate NS

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -364,7 +364,7 @@ func Test_deleteDynamicResource(t *testing.T) {
 			"name":      "channel-new-default-excluded",
 			"namespace": "default",
 			"labels": map[string]interface{}{
-				"velero.io/exclude-from-backup": "true",
+				ExcludeBackupLabel: "true",
 			},
 		},
 		"spec": map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/26385

Don't backup MSA and manifest work
Before the MSA is created, delete any secrets with the same name ( if this is a passive - becoming active, there could be secrets created by the MSA on the initial primary; those secrets should be removed since this hub should enable MSA support before using the MSA feature; and creating new secrets with the same MSA won't work)