### PR TITLE
remove keepAutoImportSecret annotation

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -36,8 +36,6 @@ const (
 	/* #nosec G101 -- This is a false positive */
 	activateLabel = "cluster.open-cluster-management.io/restore-auto-import-secret"
 	/* #nosec G101 -- This is a false positive */
-	keepAutoImportSecret = "managedcluster-import-controller.open-cluster-management.io/keeping-auto-import-secret"
-	/* #nosec G101 -- This is a false positive */
 	autoImportSecretName = "auto-import-secret"
 )
 

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -549,10 +549,6 @@ func createAutoImportSecret(
 	autoImportSecret.Name = autoImportSecretName
 	autoImportSecret.Namespace = namespace
 	autoImportSecret.Type = corev1.SecretTypeOpaque
-	// set annotations
-	annotations := make(map[string]string)
-	annotations[keepAutoImportSecret] = ""
-	autoImportSecret.SetAnnotations(annotations)
 	// set labels
 	labels := make(map[string]string)
 	labels[activateLabel] = "true"


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>
https://github.com/stolostron/backlog/issues/26911

there are some issues with the annotation
I noticed on more tests that the managed cluster gets into an unknown state if the secret is not deleted

Let's back this up until the cluster lifecycle team identify that this is the right approach.
I opened https://issues.redhat.com/browse/ACM-2160 for them to first make sure the annotation is really useful

Scenario that breaks our existing tests:

- backup with MSA
- stop managed cluster
- restore on new hub
- the auto import is kept now because of the annotation; the retry gets to 0
- now start the managed cluster
- fix the import by setting the retry to 1 on the auto import secret
- I see the managed cluster in active status, as expected
- but now I am creating a new BackupSchedule on the new hub; this resets the old MSA token; so the auto import is still there, but with an invalid token; the managed cluster got into an unknown state; I assume the reason is that the auto import secret exists and the token is invalid