### PR TITLE
add tests for isVeleroSchedulesUpdateRequired

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -211,6 +211,21 @@ func (b *ScheduleHelper) scheduleLabels(labels map[string]string) *ScheduleHelpe
 	return b
 }
 
+func (b *ScheduleHelper) schedule(cronjob string) *ScheduleHelper {
+	b.object.Spec.Schedule = cronjob
+	return b
+}
+
+func (b *ScheduleHelper) phase(ph veleroapi.SchedulePhase) *ScheduleHelper {
+	b.object.Status.Phase = ph
+	return b
+}
+
+func (b *ScheduleHelper) ttl(duration metav1.Duration) *ScheduleHelper {
+	b.object.Spec.Template.TTL = duration
+	return b
+}
+
 // velero restore
 type RestoreHelper struct {
 	object *veleroapi.Restore

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -218,19 +218,15 @@ func Test_postRestoreActivation(t *testing.T) {
 		},
 	}
 
-	for index, tt := range tests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got, _ := postRestoreActivation(tt.args.ctx, k8sClient1,
 				tt.args.secrets, tt.args.managedClusters, tt.args.currentTime); len(got) != len(tt.want) {
 				t.Errorf("postRestoreActivation() returns = %v, want %v", got, tt.want)
 			}
 		})
-
-		if index == len(tests)-1 {
-			testEnv.Stop()
-		}
 	}
-
+	testEnv.Stop()
 }
 
 func Test_executePostRestoreTasks(t *testing.T) {

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -624,12 +624,9 @@ func Test_getVeleroBackupName(t *testing.T) {
 				t.Errorf("getVeleroBackupName() returns = %v, want %v", name, tt.want)
 			}
 		})
-		if index == len(tests)-1 {
-			// clean up
-			testEnv.Stop()
-		}
 	}
-
+	// clean up
+	testEnv.Stop()
 }
 
 func Test_isNewBackupAvailable(t *testing.T) {

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -503,3 +503,47 @@ func createFailedValidationResponse(
 		)
 
 }
+
+// check if Velero schedules need to be updated and update them if required
+func isVeleroSchedulesUpdateRequired(
+	ctx context.Context,
+	c client.Client,
+	resourcesToBackup []string,
+	veleroScheduleList veleroapi.ScheduleList,
+	backupSchedule *v1beta1.BackupSchedule,
+) (ctrl.Result, bool, error) {
+	scheduleLogger := log.FromContext(ctx)
+
+	// update velero schedules if cron schedule or ttl is changed on the backupSchedule
+	if isScheduleSpecUpdated(&veleroScheduleList, backupSchedule) {
+		for i := range veleroScheduleList.Items {
+			veleroSchedule := &veleroScheduleList.Items[i]
+			if err := c.Update(ctx, veleroSchedule, &client.UpdateOptions{}); err != nil {
+				return ctrl.Result{}, true, err
+			}
+		}
+		scheduleLogger.Info(
+			fmt.Sprintf("Updated Velero schedules spec based on %s spec ", backupSchedule.Name),
+		)
+		return ctrl.Result{RequeueAfter: collisionControlInterval}, true, nil
+	}
+
+	// update backup resources on velero schedules if any changes in hub resources
+	schedulesToBeUpdated := getSchedulesWithUpdatedResources(resourcesToBackup, &veleroScheduleList)
+	if schedulesToBeUpdated != nil && len(schedulesToBeUpdated) > 0 {
+		for i := range schedulesToBeUpdated {
+			if err := c.Update(ctx, &schedulesToBeUpdated[i], &client.UpdateOptions{}); err != nil {
+				return ctrl.Result{}, true, err
+			}
+			scheduleLogger.Info(
+				fmt.Sprintf(
+					"Updated backup resources on Velero schedule %s ",
+					schedulesToBeUpdated[i].Name,
+				),
+			)
+		}
+		return ctrl.Result{RequeueAfter: collisionControlInterval}, true, nil
+	}
+
+	return ctrl.Result{}, false, nil
+}

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -151,12 +151,6 @@ func (r *BackupScheduleReconciler) Reconcile(
 		client.InNamespace(req.Namespace),
 		client.MatchingFields{scheduleOwnerKey: req.Name},
 	); err != nil {
-		scheduleLogger.Error(
-			err,
-			"unable to list velero schedules for schedule",
-			"namespace", req.Namespace,
-			"name", req.Name,
-		)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -123,7 +123,6 @@ func (r *BackupScheduleReconciler) Reconcile(
 	)
 
 	backupSchedule := &v1beta1.BackupSchedule{}
-
 	if result, validConfiguration, err := r.isValidateConfiguration(ctx, mapper,
 		req,
 		backupSchedule); !validConfiguration {
@@ -225,7 +224,8 @@ func (r *BackupScheduleReconciler) Reconcile(
 	}
 
 	// check for any updates that are required for velero schedules based on backupSchedule and hub resources
-	if result, updated, err := r.isVeleroSchedulesUpdateRequired(ctx, veleroScheduleList, backupSchedule); updated {
+	if result, updated, err := isVeleroSchedulesUpdateRequired(ctx, r.Client,
+		getResourcesToBackup(ctx, r.DiscoveryClient), veleroScheduleList, backupSchedule); updated {
 		return result, err
 	}
 
@@ -244,49 +244,6 @@ func (r *BackupScheduleReconciler) Reconcile(
 			backupSchedule.Name,
 		),
 	)
-}
-
-// check if Velero schedules need to be updated and update them if required
-func (r *BackupScheduleReconciler) isVeleroSchedulesUpdateRequired(
-	ctx context.Context,
-	veleroScheduleList veleroapi.ScheduleList,
-	backupSchedule *v1beta1.BackupSchedule,
-) (ctrl.Result, bool, error) {
-	scheduleLogger := log.FromContext(ctx)
-
-	// update velero schedules if cron schedule or ttl is changed on the backupSchedule
-	if isScheduleSpecUpdated(&veleroScheduleList, backupSchedule) {
-		for i := range veleroScheduleList.Items {
-			veleroSchedule := &veleroScheduleList.Items[i]
-			if err := r.Client.Update(ctx, veleroSchedule, &client.UpdateOptions{}); err != nil {
-				return ctrl.Result{}, true, err
-			}
-		}
-		scheduleLogger.Info(
-			fmt.Sprintf("Updated Velero schedules spec based on %s spec ", backupSchedule.Name),
-		)
-		return ctrl.Result{RequeueAfter: collisionControlInterval}, true, nil
-	}
-
-	// update backup resources on velero schedules if any changes in hub resources
-	resourcesToBackup := getResourcesToBackup(ctx, r.DiscoveryClient)
-	schedulesToBeUpdated := getSchedulesWithUpdatedResources(resourcesToBackup, &veleroScheduleList)
-	if schedulesToBeUpdated != nil && len(schedulesToBeUpdated) > 0 {
-		for i := range schedulesToBeUpdated {
-			if err := r.Client.Update(ctx, &schedulesToBeUpdated[i], &client.UpdateOptions{}); err != nil {
-				return ctrl.Result{}, true, err
-			}
-			scheduleLogger.Info(
-				fmt.Sprintf(
-					"Updated backup resources on Velero schedule %s ",
-					schedulesToBeUpdated[i].Name,
-				),
-			)
-		}
-		return ctrl.Result{RequeueAfter: collisionControlInterval}, true, nil
-	}
-
-	return ctrl.Result{}, false, nil
 }
 
 // validate backup configuration

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -510,7 +510,7 @@ var _ = Describe("BackupSchedule controller", func() {
 				createdBackupSchedule.Status.VeleroScheduleResources.Spec.Template.TTL,
 			).Should(Equal(metav1.Duration{Duration: time.Hour * 72}))
 
-			// update schedule, it should trigger velero schedules deletion
+			// update schedule, it should NOT trigger velero schedules deletion
 			createdBackupSchedule.Spec.VeleroTTL = metav1.Duration{Duration: time.Hour * 150}
 			Expect(
 				k8sClient.
@@ -525,7 +525,22 @@ var _ = Describe("BackupSchedule controller", func() {
 				return createdBackupSchedule.Spec.VeleroTTL
 			}, timeout, interval).Should(BeIdenticalTo(metav1.Duration{Duration: time.Hour * 150}))
 
-			// check that the velero schedules are new - have now 150h for ttl
+			// delete one schedule, it should trigger velero schedules recreation
+			veleroSchedulesList := veleroapi.ScheduleList{}
+			Eventually(func() bool {
+				err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{})
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			k8sClient.Delete(ctx, &veleroSchedulesList.Items[1])
+			// count velero schedules, should be still len(veleroScheduleNames)
+			Eventually(func() int {
+				if err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{}); err == nil {
+					return len(veleroSchedulesList.Items)
+				}
+				return 0
+			}, time.Second*65, interval).Should(BeNumerically("==", len(veleroScheduleNames)))
+
+			// check that the velero schedules have now 150h for ttl
 			Eventually(func() metav1.Duration {
 				err := k8sClient.Get(ctx, backupLookupKey, &createdBackupSchedule)
 				if err != nil {
@@ -538,7 +553,7 @@ var _ = Describe("BackupSchedule controller", func() {
 			}, timeout, interval).Should(BeIdenticalTo(metav1.Duration{Duration: time.Hour * 150}))
 
 			// count velero schedules, should be still len(veleroScheduleNames)
-			veleroSchedulesList := veleroapi.ScheduleList{}
+			//veleroSchedulesList := veleroapi.ScheduleList{}
 			Eventually(func() bool {
 				err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{})
 				return err == nil
@@ -594,7 +609,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					return "unknown"
 				}
 				return string(createdBackupSchedule.Status.Phase)
-			}, timeout, interval).Should(BeIdenticalTo(string(v1beta1.SchedulePhaseBackupCollision)))
+			}, time.Second*65, interval).Should(BeIdenticalTo(string(v1beta1.SchedulePhaseBackupCollision)))
 
 			// new schedule backup
 			backupScheduleName3 := backupScheduleName + "-3"

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -553,7 +553,6 @@ var _ = Describe("BackupSchedule controller", func() {
 			}, timeout, interval).Should(BeIdenticalTo(metav1.Duration{Duration: time.Hour * 150}))
 
 			// count velero schedules, should be still len(veleroScheduleNames)
-			//veleroSchedulesList := veleroapi.ScheduleList{}
 			Eventually(func() bool {
 				err := k8sClient.List(ctx, &veleroSchedulesList, &client.ListOptions{})
 				return err == nil

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -352,6 +352,8 @@ func Test_getSchedulesWithUpdatedResources(t *testing.T) {
 			}
 		})
 	}
+	// clean up
+	testEnv.Stop()
 }
 
 func Test_isScheduleSpecUpdated(t *testing.T) {

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -560,10 +560,8 @@ func Test_getHubIdentification(t *testing.T) {
 				t.Errorf("getHubIdentification() returns no error = %v, want %v and version=%v want=%v", err == nil, tt.err_nil, version, tt.want_msg)
 			}
 		})
-		if index == len(tests)-1 {
-			// clean up
-			testEnv.Stop()
-		}
 	}
+	// clean up
+	testEnv.Stop()
 
 }


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Add tests for getSchedulesWithUpdatedResources

https://github.com/stolostron/backlog/issues/26765
https://github.com/stolostron/cluster-backup-operator/pull/362

Changes:
- refactor getSchedulesWithUpdatedResources 
- create new testcase for getSchedulesWithUpdatedResources
- update existing testcases to allow reconcile being called when the BackupSchedule ttl is changed
