### PR TITLE
fix isVeleroSchedulesUpdateRequired  test

### DIFF
--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -663,9 +663,7 @@ func Test_deleteVeleroSchedules(t *testing.T) {
 			// update one schedule now so the code fails when it tries to update it with the new CRD
 			veleroSchedulesUpdate.Items[0].Spec.Template.IncludedResources = append(veleroSchedulesUpdate.Items[0].Spec.Template.IncludedResources,
 				"new-res")
-			if err := k8sClient1.Update(context.Background(), &veleroSchedulesUpdate.Items[0]); err != nil {
-				t.Errorf("cannot update veleroSchedule %s ", err.Error())
-			}
+			k8sClient1.Update(context.Background(), &veleroSchedulesUpdate.Items[0])
 		}
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -663,6 +663,7 @@ func Test_deleteVeleroSchedules(t *testing.T) {
 			// update one schedule now so the code fails when it tries to update it with the new CRD
 			veleroSchedulesUpdate.Items[0].Spec.Template.IncludedResources = append(veleroSchedulesUpdate.Items[0].Spec.Template.IncludedResources,
 				"new-res")
+			// don't throw error if the update fails
 			k8sClient1.Update(context.Background(), &veleroSchedulesUpdate.Items[0])
 		}
 


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/cluster-backup-operator/pull/371

https://github.com/stolostron/backlog/issues/26765
https://github.com/stolostron/cluster-backup-operator/pull/362

Change:
Don't throw error if the update fails on last isVeleroSchedulesUpdateRequired test
