### PR TITLE
backup clusterimageset in 2.6

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -107,6 +107,7 @@ var (
 		"baremetalhost.metal3.io",
 		"bmceventsubscription.metal3.io",
 		"hostfirmwaresettings.metal3.io",
+		"clusterimageset.hive.openshift.io",
 	}
 
 	// all backup resources, except secrets, configmaps and managed cluster activation resources


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

It's been observed that since clusterimagesets are not backed up, the clusterpool(s) which use the custom imageset will not be able to scale/claim after restore activation.
Fix: add clusterimageset CR to backup

https://issues.redhat.com/browse/ACM-2288