### PR TITLE
don't backup hive import secrets

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -75,6 +75,8 @@ const (
             }
         ]
     }`
+
+	update_msg = "Updated secret %s in ns %s"
 )
 
 // the prepareForBackup task is executed before each run of a backup schedule
@@ -557,7 +559,7 @@ func updateMSAResources(
 			logger.Info(fmt.Sprintf("Attempt to update secret %s in ns %s", secret.Name, secret.Namespace))
 
 			if err := c.Update(ctx, &secret, &client.UpdateOptions{}); err == nil {
-				logger.Info(fmt.Sprintf("Updated secret %s in ns %s", secret.Name, secret.Namespace))
+				logger.Info(fmt.Sprintf(update_msg, secret.Name, secret.Namespace))
 			}
 		}
 	}
@@ -743,7 +745,7 @@ func updateSecretsLabels(ctx context.Context,
 				msg := fmt.Sprintf("Updating secret %s in ns %s, removing label %s", secret.Name, secret.Namespace, labelName)
 				logger.Info(msg)
 				if err := c.Update(ctx, &secret, &client.UpdateOptions{}); err == nil {
-					logger.Info(fmt.Sprintf("Updated secret %s in ns %s", secret.Name, secret.Namespace))
+					logger.Info(fmt.Sprintf(update_msg, secret.Name, secret.Namespace))
 				}
 			}
 			continue
@@ -784,7 +786,7 @@ func updateSecret(ctx context.Context,
 			return true
 		}
 		if err := c.Update(ctx, &secret, &client.UpdateOptions{}); err == nil {
-			logger.Info(fmt.Sprintf("Updated secret %s in ns %s", secret.Name, secret.Namespace))
+			logger.Info(fmt.Sprintf(update_msg, secret.Name, secret.Namespace))
 		}
 		// secret needs refresh
 		return true


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://issues.redhat.com/browse/ACM-2327

Reported issue
Steps to Reproduce:

1. On prim hub, create clusterpool + claim a managed cluster >> OK
2. Hibernate the managed cluster claimed in step 1
3. Create backup schedule >> backups created successfully
4. Shutdown prim hub, run restore activation on second hub
5. Managed cluster restored on second hub in hibernating state
6. Resume the hibernating managed cluster in step 5

Actual results:
The resumed managed cluster is stuck at 'Pending import'


When we backup a cluster, we should not backup its import secret, we should let import controller create it in the new hub