### PR TITLE
always attempt to create MSA manifest work

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -344,6 +344,10 @@ func createMSA(
 ) (bool, bool, error) {
 
 	logger := log.FromContext(ctx)
+
+	// attempt to create ManifestWork to push the role binding, if not created already
+	createManifestWork(ctx, c, managedClusterName)
+
 	secretsGeneratedNow := false
 
 	//check if MSA exists
@@ -409,8 +413,7 @@ func createMSA(
 		if _, err := dr.Namespace(managedClusterName).Create(ctx, msaRC, v1.CreateOptions{}); err == nil {
 			logger.Info(fmt.Sprintf("Created ManagedServiceAccount for cluster =%s", managedClusterName))
 		}
-		// create ManifestWork to push the role binding
-		createManifestWork(ctx, c, managedClusterName)
+
 	}
 
 	return secretsGeneratedNow, false, nil


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/27027

Issue
Sometimes the MSA rolebinding is not lost on the managed cluster, even if the role still exists
Fix : attempt to  create the MSA manifest work on the hub even if the MSA addon exists
