### PR TITLE
backup MSA ManifestWork

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -481,8 +481,8 @@ func createManifestWork(
 				manifestWork.Name = manifest_work_name
 				manifestWork.Namespace = namespace
 				manifestWork.Labels = map[string]string{
-					addon_work_label:   msa_addon,
-					ExcludeBackupLabel: "true"}
+					addon_work_label:        msa_addon,
+					backupCredsClusterLabel: "msa"}
 
 				manifest := &workv1.Manifest{}
 				manifest.Raw = []byte(fmt.Sprintf(manifestwork, role_name, msa_service_name))


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://issues.redhat.com/browse/ACM-2466

Issue:
managed-serviceaccount-import appliedmanifestwork left orphaned on managed cluster after detaching on restored hub
Version-Release number of selected component (if applicable):

How reproducible:
Steps to Reproduce:

- On prim hub, enable cluster backup + managedserviceaccount in MCE
- Import an ocp cluster 
- Enable backup schedule >> backups created successfully
- Shutdown prim hub
- On second hub, run restore activation
- The imported cluster gets registered successfully to the second hub
- Detach the imported cluster on the second hub

Actual results:
managed-serviceaccount-import appliedmanifestwork left orphaned on managed cluster after being detached

Fix:
Backup the ManifestWork resource for MSA 
 Resources `work.open-cluster-management.io` api group are excluded from backup so in order to backup the MSA manifest work, we add the `cluster.open-cluster-management.io/backup` to this resource
As a result the MSA ManifestWork is backed up under the `acm-resources-generic-schedule`

```
apiVersion: work.open-cluster-management.io/v1
kind: ManifestWork
metadata:
  resourceVersion: '548706'
  name: addon-managed-serviceaccount-import
  uid: 78b51075-3bf8-470f-a9e5-92e54794f57e
  creationTimestamp: '2022-12-20T17:22:49Z'
  generation: 1
  namespace: vb-managed-1
  finalizers:
    - cluster.open-cluster-management.io/manifest-work-cleanup
  labels:
    cluster.open-cluster-management.io/backup: msa <<<<<<<<<<<<<
    open-cluster-management.io/addon-name-work: managed-serviceaccount
spec:
  workload:
    manifests:
      - apiVersion: rbac.authorization.k8s.io/v1
        kind: ClusterRoleBinding
        metadata:
          name: managedserviceaccount-import
        roleRef:
          apiGroup: rbac.authorization.k8s.io
          kind: ClusterRole
          name: klusterlet-bootstrap-kubeconfig
        subjects:
          - kind: ServiceAccount
            name: auto-import-account
            namespace: open-cluster-management-agent-addon
```
