### PR TITLE
look for BSL in the reconciled resource ns

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -450,7 +450,8 @@ func validateStorageSettings(
 	// look for available VeleroStorageLocation
 	// and keep track of the velero oadp namespace
 	isValidStorageLocation, veleroNamespace := isValidStorageLocationDefined(
-		*veleroStorageLocations,
+		veleroStorageLocations.Items,
+		namespace,
 	)
 
 	if !isValidStorageLocation {

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -449,7 +449,7 @@ func validateStorageSettings(
 
 	// look for available VeleroStorageLocation
 	// and keep track of the velero oadp namespace
-	isValidStorageLocation, veleroNamespace := isValidStorageLocationDefined(
+	isValidStorageLocation := isValidStorageLocationDefined(
 		veleroStorageLocations.Items,
 		namespace,
 	)
@@ -457,19 +457,6 @@ func validateStorageSettings(
 	if !isValidStorageLocation {
 		msg = "Backup storage location not available in namespace " + namespace +
 			". Check velero.io.BackupStorageLocation and validate storage credentials."
-
-		return msg, retry
-	}
-
-	// return error if the cluster restore file is not in the same namespace with velero
-	if veleroNamespace != namespace {
-		msg = fmt.Sprintf(
-			"Restore resource [%s/%s] must be created in the velero namespace [%s]",
-			namespace,
-			name,
-			veleroNamespace,
-		)
-		retry = false
 
 		return msg, retry
 	}

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -864,8 +864,7 @@ var _ = Describe("Basic Restore controller", func() {
 				}, timeout, interval).Should(BeEquivalentTo(v1beta1.RestorePhaseError))
 				Expect(
 					createdRestore.Status.LastMessage,
-				).Should(BeIdenticalTo("Restore resource [acm-ns-1/rhacm-restore-1-new] " +
-					"must be created in the velero namespace [velero-restore-ns-5]"))
+				).Should(BeIdenticalTo("Backup storage location not available in namespace acm-ns-1. Check velero.io.BackupStorageLocation and validate storage credentials."))
 			},
 		)
 	})

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -289,7 +289,8 @@ func (r *BackupScheduleReconciler) isValidateConfiguration(
 	// look for available VeleroStorageLocation
 	// and keep track of the velero oadp namespace
 	isValidStorageLocation, veleroNamespace := isValidStorageLocationDefined(
-		*veleroStorageLocations,
+		veleroStorageLocations.Items,
+		req.Namespace,
 	)
 
 	// if no valid storage location found wait for valid value

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -288,7 +288,7 @@ func (r *BackupScheduleReconciler) isValidateConfiguration(
 
 	// look for available VeleroStorageLocation
 	// and keep track of the velero oadp namespace
-	isValidStorageLocation, veleroNamespace := isValidStorageLocationDefined(
+	isValidStorageLocation := isValidStorageLocationDefined(
 		veleroStorageLocations.Items,
 		req.Namespace,
 	)
@@ -299,18 +299,6 @@ func (r *BackupScheduleReconciler) isValidateConfiguration(
 			"Check velero.io.BackupStorageLocation and validate storage credentials."
 		return createFailedValidationResponse(ctx, r.Client, backupSchedule,
 			msg, true)
-	}
-
-	// return error if the backup resource is not in the same namespace with velero
-	if veleroNamespace != req.Namespace {
-		msg := fmt.Sprintf(
-			"Schedule resource [%s/%s] must be created in the velero namespace [%s]",
-			req.Namespace,
-			req.Name,
-			veleroNamespace,
-		)
-		return createFailedValidationResponse(ctx, r.Client, backupSchedule,
-			msg, false)
 	}
 
 	// check MSA status for backup schedules

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -686,7 +686,7 @@ var _ = Describe("BackupSchedule controller", func() {
 			}, timeout, interval).Should(BeTrue())
 			Expect(
 				createdBackupScheduleACM.Status.LastMessage,
-			).Should(ContainSubstring("must be created in the velero namespace"))
+			).Should(ContainSubstring("location is not available"))
 
 			// backup with invalid cron job schedule, should fail validation
 			invalidCronExpBackupName := backupScheduleName + "-invalid-cron-exp"

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -138,17 +138,19 @@ func (a SortResourceType) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 // check if we have a valid storage location object
 func isValidStorageLocationDefined(
-	veleroStorageLocations veleroapi.BackupStorageLocationList,
+	veleroStorageLocations []veleroapi.BackupStorageLocation,
+	preferredNs string,
 ) (bool, string) {
 	isValidStorageLocation := false
 	veleroNamespace := ""
-	for i := range veleroStorageLocations.Items {
-		if veleroStorageLocations.Items[i].OwnerReferences != nil &&
-			veleroStorageLocations.Items[i].Status.Phase == veleroapi.BackupStorageLocationPhaseAvailable {
-			for _, ref := range veleroStorageLocations.Items[i].OwnerReferences {
+	for i := range veleroStorageLocations {
+		if veleroStorageLocations[i].Namespace == preferredNs &&
+			veleroStorageLocations[i].OwnerReferences != nil &&
+			veleroStorageLocations[i].Status.Phase == veleroapi.BackupStorageLocationPhaseAvailable {
+			for _, ref := range veleroStorageLocations[i].OwnerReferences {
 				if ref.Kind != "" {
 					isValidStorageLocation = true
-					veleroNamespace = veleroStorageLocations.Items[i].Namespace
+					veleroNamespace = veleroStorageLocations[i].Namespace
 					break
 				}
 			}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -140,9 +140,8 @@ func (a SortResourceType) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func isValidStorageLocationDefined(
 	veleroStorageLocations []veleroapi.BackupStorageLocation,
 	preferredNs string,
-) (bool, string) {
+) bool {
 	isValidStorageLocation := false
-	veleroNamespace := ""
 	for i := range veleroStorageLocations {
 		if veleroStorageLocations[i].Namespace == preferredNs &&
 			veleroStorageLocations[i].OwnerReferences != nil &&
@@ -150,7 +149,6 @@ func isValidStorageLocationDefined(
 			for _, ref := range veleroStorageLocations[i].OwnerReferences {
 				if ref.Kind != "" {
 					isValidStorageLocation = true
-					veleroNamespace = veleroStorageLocations[i].Namespace
 					break
 				}
 			}
@@ -159,7 +157,7 @@ func isValidStorageLocationDefined(
 			break
 		}
 	}
-	return isValidStorageLocation, veleroNamespace
+	return isValidStorageLocation
 }
 
 // having a resourceKind.resourceGroup string, return (resourceKind, resourceGroup)

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -253,7 +253,7 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := isValidStorageLocationDefined(*&tt.args.veleroStorageLocations.Items,
+			if got := isValidStorageLocationDefined(*&tt.args.veleroStorageLocations.Items,
 				tt.args.preferredNS); got != tt.want {
 				t.Errorf("isValidStorageLocationDefined() = %v, want %v", got, tt.want)
 			}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -135,6 +135,7 @@ func Test_sortCompare(t *testing.T) {
 func Test_isValidStorageLocationDefined(t *testing.T) {
 	type args struct {
 		veleroStorageLocations *veleroapi.BackupStorageLocationList
+		preferredNS            string
 	}
 	tests := []struct {
 		name string
@@ -147,6 +148,7 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 				veleroStorageLocations: &veleroapi.BackupStorageLocationList{
 					Items: make([]veleroapi.BackupStorageLocation, 0),
 				},
+				preferredNS: "",
 			},
 			want: false,
 		},
@@ -170,6 +172,7 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 						},
 					},
 				},
+				preferredNS: "default",
 			},
 			want: false,
 		},
@@ -198,13 +201,60 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 						},
 					},
 				},
+				preferredNS: "default",
 			},
 			want: true,
+		},
+		{
+			name: "Storage location valid but not using the preferred ns",
+			args: args{
+				veleroStorageLocations: &veleroapi.BackupStorageLocationList{
+					Items: []veleroapi.BackupStorageLocation{
+						veleroapi.BackupStorageLocation{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero/v1",
+								Kind:       "BackupStorageLocation",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "valid-storage",
+								Namespace: "default1",
+								OwnerReferences: []v1.OwnerReference{
+									v1.OwnerReference{
+										Kind: "DataProtectionApplication",
+									},
+								},
+							},
+							Status: veleroapi.BackupStorageLocationStatus{
+								Phase: veleroapi.BackupStorageLocationPhaseAvailable,
+							},
+						},
+						veleroapi.BackupStorageLocation{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero/v1",
+								Kind:       "BackupStorageLocation",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "valid-storage",
+								Namespace: "default",
+								OwnerReferences: []v1.OwnerReference{
+									v1.OwnerReference{
+										Kind: "DataProtectionApplication",
+									},
+								},
+							},
+							Status: veleroapi.BackupStorageLocationStatus{},
+						},
+					},
+				},
+				preferredNS: "default",
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := isValidStorageLocationDefined(*tt.args.veleroStorageLocations); got != tt.want {
+			if got, _ := isValidStorageLocationDefined(*&tt.args.veleroStorageLocations.Items,
+				tt.args.preferredNS); got != tt.want {
 				t.Errorf("isValidStorageLocationDefined() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://issues.redhat.com/browse/ACM-2505

Steps to Reproduce:

- On ROSA hub, install ACM + enable backup
- Create DPA + backupstorage location >> OK
- Enable backup schedule
- Actual results:  Backup schedule failed


```
#oc get dpa -A
NAMESPACE                        NAME     AGE
open-cluster-management-backup   velero   6m3s

#oc get bsl -A
NAMESPACE                        NAME       PHASE       LAST VALIDATED   AGE     DEFAULT
open-cluster-management-backup   velero-1   Available   42s              6m16s   true
openshift-velero                 default    Available   11m              8d      true


#oc get bsch -A
NAMESPACE                        NAME           PHASE              MESSAGE
open-cluster-management-backup   schedule-acm   FailedValidation   Schedule resource [open-cluster-management-backup/schedule-acm] must be created in the velero namespace [openshift-velero] 
```


Fix:

Look for a valid BackupStorageLocation resource in the namespace where the BackupSchedule is created

Rosa uses velero to backup cluster resources and in this case there are 2 versions of BackupStorageLocation resources defined on the hub. We want to look for the BSL in the ns where the BackupSchedule is created so that it doesn't validate against the Rosa velero settings