### PR TITLE
allow activation resources by group api

### DIFF
--- a/config/samples/cluster_v1beta1_backupschedule.yaml
+++ b/config/samples/cluster_v1beta1_backupschedule.yaml
@@ -9,5 +9,5 @@ metadata:
   name: schedule-acm
   namespace: open-cluster-management-backup
 spec:
-  veleroSchedule: 0 */2 * * *
+  veleroSchedule: 0 */1 * * *
   veleroTtl: 120h

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -66,6 +66,7 @@ var (
 	}
 	includedActivationAPIGroupsByName = []string{
 		"hypershift.openshift.io",
+		"machine.openshift.io",
 		"infrastructure.cluster.x-k8s.io",
 		"agent-install.openshift.io",
 	}

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -65,9 +65,6 @@ var (
 		"core.observatorium.io",
 	}
 	includedActivationAPIGroupsByName = []string{
-		"hypershift.openshift.io",
-		"machine.openshift.io",
-		"infrastructure.cluster.x-k8s.io",
 		"agent-install.openshift.io",
 	}
 

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -515,7 +515,6 @@ func processResourcesToBackup(
 					// and this is an activation group
 					// add the reqource to the activation list and return
 					backupManagedClusterResources = appendUnique(backupManagedClusterResources, resourceName)
-					continue
 				}
 
 				// if resource kind is not ignored

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -513,14 +513,13 @@ func processResourcesToBackup(
 					!findValue(ignoreCRDs, resourceName) {
 					// if resource kind is not ignored
 					// and this is an activation group
-					// add the reqource to the activation list and return
+					// then add the resource to the activation list
 					backupManagedClusterResources = appendUnique(backupManagedClusterResources, resourceName)
 				}
 
 				// if resource kind is not ignored
-				// and kind.group is not used to identify resource to ignore
-				// the resource is not in cluster activation backup group
-				// add it to the generic backup resources
+				// and the resource is not in cluster activation backup group
+				// then add it to the backup resources
 				if !findValue(includedActivationAPIGroupsByName, group.Name) &&
 					!findValue(ignoreCRDs, resourceKind) &&
 					!findValue(ignoreCRDs, resourceName) &&
@@ -546,11 +545,11 @@ func shouldBackupAPIGroup(groupStr string) bool {
 	_, ok = find(includedAPIGroupsByName, groupStr)
 	// if not in the included api groups
 	if !ok {
-		// check if is in the activation included api groups
+		// check if is in the activation api groups list
 		_, ok = find(includedActivationAPIGroupsByName, groupStr)
 
 	}
-	// if not in the included api groups
+	// if not in the activation api groups
 	if !ok {
 		// check if is in the included api groups by suffix
 		_, ok = findSuffix(includedAPIGroupsSuffix, groupStr)

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -536,7 +536,7 @@ var _ = Describe("BackupSchedule controller", func() {
 			Expect(
 				veleroSchedulesList.Items[1].Spec.Template.VolumeSnapshotLocations,
 			).Should(Equal([]string{"dpa-1"}))
-			// check clusterpool.other.hive.openshift.io be be in the managed cluster schedule and not in resources
+			// verify clusterpool.other.hive.openshift.io to be in the managed cluster schedule and not in resources backup
 			// because the includedActivationAPIGroupsByName contains other.hive.openshift.io
 			for i := range veleroSchedulesList.Items {
 				if veleroSchedulesList.Items[i].Name == veleroScheduleNames[Resources] {

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -536,6 +536,20 @@ var _ = Describe("BackupSchedule controller", func() {
 			Expect(
 				veleroSchedulesList.Items[1].Spec.Template.VolumeSnapshotLocations,
 			).Should(Equal([]string{"dpa-1"}))
+			// check clusterpool.other.hive.openshift.io be be in the managed cluster schedule and not in resources
+			// because the includedActivationAPIGroupsByName contains other.hive.openshift.io
+			for i := range veleroSchedulesList.Items {
+				if veleroSchedulesList.Items[i].Name == veleroScheduleNames[Resources] {
+					Expect(findValue(veleroSchedulesList.Items[i].Spec.Template.IncludedResources,
+						"clusterpool.other.hive.openshift.io")).Should(BeFalse())
+
+				}
+				if veleroSchedulesList.Items[i].Name == veleroScheduleNames[ManagedClusters] {
+					Expect(findValue(veleroSchedulesList.Items[i].Spec.Template.IncludedResources,
+						"clusterpool.other.hive.openshift.io")).Should(BeTrue())
+
+				}
+			}
 
 			k8sClient.Delete(ctx, &veleroSchedulesList.Items[1])
 			// count velero schedules, should be still len(veleroScheduleNames)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -368,6 +368,11 @@ var _ = BeforeSuite(func() {
 	resourcesToBackup = []string{
 		"placement.cluster.open-cluster-management.io",
 	}
+
+	//clusterpool.other.hive.openshift.io should go under managed cluster backup
+	includedActivationAPIGroupsByName = []string{
+		"other.hive.openshift.io",
+	}
 	test := tests[1]
 	_, err := fakeDiscovery.ServerResourcesForGroupVersion(test.request)
 


### PR DESCRIPTION
Allow specifying the apiGroup for resources that need to be restored at activation time

backup agent installer as activation data resource 

Changes:
- introduced a new group includedActivationAPIGroupsByName , similar with includedAPIGroupsByName
- resources with the api groups which are part of the includedActivationAPIGroupsByName list will be stored under the acm-managed-clusters-schedule and will be restored at activation time, with the managed cluster resources
- moved the agent-install.openshift.io under this group
