### PR TITLE
use go install for getting build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -11,8 +11,6 @@ build-prow:
 	docker build -f Dockerfile . -t ${REPO_URL}/cluster-backup-operator:${VERSION}
 
 .PHONY: unit-tests
-export HOME = /tmp/home
 unit-tests:
-	mkdir $(HOME)
 	GOFLAGS="" go test -timeout 500s -v -short ./controllers
 	


### PR DESCRIPTION
- also set HOME only in build target inside Makefile.prow so it doesn't override for everything