### PR TITLE
create ManifestWork for auto-import-account-pair

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -507,7 +507,7 @@ func createManifestWork(
 					backupCredsClusterLabel: "msa"}
 
 				manifest := &workv1.Manifest{}
-				manifest.Raw = []byte(fmt.Sprintf(manifestwork, mworkbindingName, role_name, msaserviceName)) //msa_service_name))
+				manifest.Raw = []byte(fmt.Sprintf(manifestwork, mworkbindingName, role_name, msaserviceName))
 
 				manifestWork.Spec.Workload.Manifests = []workv1.Manifest{
 					*manifest,


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-4612

When enabling the automatic import feature, https://github.com/stolostron/cluster-backup-operator#enabling-the-automatic-import-feature, the controller creates a ManagedServiceAccount named auto-import-account and sets the token validity as defined by the BackupSchedule. 
At half time expiration, a new auto-import-account-pair is created to overlap with the initial auto-import-account so that if the initial token has expired when the backup is restored, the second token can be used ( it increases the probability that the auto-import-account part of the backup is valid at the time the backup is used )

The issue is that the ManifestWork for the  auto-import-account-pair was not created; so when the first token was invalid and the second was used instead by the post restore operation, the second token didn't have the authority to run the import operation.
The fix was to create the ManifestWork when the auto-import-account-pair gets created. 

The error when restore is called and the auto-import-account-pair is used
```
lastTransitionTime: "2023-03-28T15:02:13Z"
message: 'AutoImportSecretInvalid hosting-cluster/auto-import-secret; please check
its permission, apply resources error: secrets "bootstrap-hub-kubeconfig" is
forbidden: User "system:serviceaccount:open-cluster-management-agent-addon:auto-import-account-pair"
cannot get resource "secrets" in API group "" in the namespace "open-cluster-management-agent"'
reason: ManagedClusterImportFailed
status: "False"
type: ManagedClusterImportSucceeded
```

The workaround  is to manually create the role binding on the managed cluster after the restore fails to auto import
```
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
name:managedserviceaccount-import-pair
subjects:
-kind:ServiceAccount
name:auto-import-account-pair
namespace:open-cluster-management-agent-addon
roleRef:
apiGroup:rbac.authorization.k8s.io
kind:ClusterRole
name:klusterlet-bootstrap-kubeconfig
```