### PR TITLE
Update leader election flag names - use duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,9 +79,9 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var enableLeaderElection bool
-	var leaseDurationSeconds int
-	var renewDeadlineSeconds int
-	var retryPeriodSeconds int
+	var leaseDuration time.Duration
+	var renewDeadline time.Duration
+	var retryPeriod time.Duration
 
 	flag.StringVar(
 		&metricsAddr,
@@ -98,12 +98,19 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&leaseDurationSeconds, "lease-duration", 137,
-		"controller leader lease duration in seconds")
-	flag.IntVar(&renewDeadlineSeconds, "renew-deadline", 107,
-		"controller leader renew deadline in seconds")
-	flag.IntVar(&retryPeriodSeconds, "retry-period", 26,
-		"controller leader retry period in seconds")
+	flag.DurationVar(&leaseDuration, "leader-election-lease-duration", 137*time.Second, ""+
+		"The duration that non-leader candidates will wait after observing a leadership "+
+		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+		"slot. This is effectively the maximum duration that a leader can be stopped "+
+		"before it is replaced by another candidate. This is only applicable if leader "+
+		"election is enabled.")
+	flag.DurationVar(&renewDeadline, "leader-election-renew-deadline", 107*time.Second, ""+
+		"The interval between attempts by the acting master to renew a leadership slot "+
+		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"This is only applicable if leader election is enabled.")
+	flag.DurationVar(&retryPeriod, "leader-election-retry-period", 26*time.Second, ""+
+		"The duration the clients should wait between attempting acquisition and renewal "+
+		"of a leadership. This is only applicable if leader election is enabled.")
 
 	opts := zap.Options{
 		Development: true,
@@ -114,9 +121,10 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	leaseDuration := time.Duration(leaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(renewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(retryPeriodSeconds) * time.Second
+	setupLog.Info("Leader election settings", "enableLeaderElection", enableLeaderElection,
+		"leaseDuration", leaseDuration,
+		"renewDeadline", renewDeadline,
+		"retryPeriod", retryPeriod)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
For: https://issues.redhat.com/browse/ACM-4767

Updating flags from previous PR - using standard examples from:  https://issues.redhat.com/browse/ACM-4108

Changed: flags are now using the standard names from the above examples and are now durations.