### PR TITLE
use generic backup name on cleanup

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -137,6 +137,8 @@ type RestoreStatus struct {
 	// +kubebuilder:validation:Optional
 	VeleroResourcesRestoreName string `json:"veleroResourcesRestoreName,omitempty"`
 	// +kubebuilder:validation:Optional
+	VeleroGenericResourcesRestoreName string `json:"veleroGenericResourcesRestoreName,omitempty"`
+	// +kubebuilder:validation:Optional
 	VeleroCredentialsRestoreName string `json:"veleroCredentialsRestoreName,omitempty"`
 	// Phase is the current phase of the restore
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -1807,6 +1807,8 @@ spec:
                 type: string
               veleroCredentialsRestoreName:
                 type: string
+              veleroGenericResourcesRestoreName:
+                type: string
               veleroManagedClustersRestoreName:
                 type: string
               veleroResourcesRestoreName:

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -311,7 +311,7 @@ func (b *ACMRestoreHelper) phase(phase v1beta1.RestorePhase) *ACMRestoreHelper {
 	return b
 }
 
-func (b *ACMRestoreHelper) veleroCredentialsRestoreName(name string) *ACMRestoreHelper {
+func (b *ACMRestoreHelper) veleroStatusCredentialsName(name string) *ACMRestoreHelper {
 	b.object.Status.VeleroCredentialsRestoreName = name
 	return b
 }
@@ -328,6 +328,11 @@ func (b *ACMRestoreHelper) restorePVs(restorePV bool) *ACMRestoreHelper {
 
 func (b *ACMRestoreHelper) restoreStatus(stat *veleroapi.RestoreStatusSpec) *ACMRestoreHelper {
 	b.object.Spec.RestoreStatus = stat
+	return b
+}
+
+func (b *ACMRestoreHelper) restoreACMStatus(stat v1beta1.RestoreStatus) *ACMRestoreHelper {
+	b.object.Status = stat
 	return b
 }
 

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -311,7 +311,7 @@ func (b *ACMRestoreHelper) phase(phase v1beta1.RestorePhase) *ACMRestoreHelper {
 	return b
 }
 
-func (b *ACMRestoreHelper) veleroStatusCredentialsName(name string) *ACMRestoreHelper {
+func (b *ACMRestoreHelper) veleroCredentialsRestoreName(name string) *ACMRestoreHelper {
 	b.object.Status.VeleroCredentialsRestoreName = name
 	return b
 }

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -390,6 +390,9 @@ func (r *RestoreReconciler) initVeleroRestores(
 			if k8serr.IsAlreadyExists(err) && key == Credentials {
 				restore.Status.VeleroCredentialsRestoreName = veleroRestoresToCreate[key].Name
 			}
+			if k8serr.IsAlreadyExists(err) && key == ResourcesGeneric {
+				restore.Status.VeleroGenericResourcesRestoreName = veleroRestoresToCreate[key].Name
+			}
 		} else {
 			newVeleroRestoreCreated = true
 			r.Recorder.Event(
@@ -405,6 +408,9 @@ func (r *RestoreReconciler) initVeleroRestores(
 				restore.Status.VeleroCredentialsRestoreName = veleroRestoresToCreate[key].Name
 			case Resources:
 				restore.Status.VeleroResourcesRestoreName = veleroRestoresToCreate[key].Name
+			case ResourcesGeneric:
+				restore.Status.VeleroGenericResourcesRestoreName = veleroRestoresToCreate[key].Name
+
 			}
 		}
 	}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -698,7 +698,7 @@ func Test_isNewBackupAvailable(t *testing.T) {
 		veleroManagedClustersBackupName(skipRestore).
 		veleroCredentialsBackupName(latestBackup).
 		veleroResourcesBackupName(latestBackup).
-		veleroStatusCredentialsName(veleroRestore.Name + "11").object
+		veleroCredentialsRestoreName(veleroRestore.Name + "11").object
 
 	type args struct {
 		ctx          context.Context

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -698,7 +698,7 @@ func Test_isNewBackupAvailable(t *testing.T) {
 		veleroManagedClustersBackupName(skipRestore).
 		veleroCredentialsBackupName(latestBackup).
 		veleroResourcesBackupName(latestBackup).
-		veleroCredentialsRestoreName(veleroRestore.Name + "11").object
+		veleroStatusCredentialsName(veleroRestore.Name + "11").object
 
 	type args struct {
 		ctx          context.Context


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-5953

New output for restore (veleroGenericResourcesRestoreName); this will be used to find the backup name for the generic resources. Before this change, the generic resources backup name was computed from the resources backup and this could result in cleaning up generic resources  if the resources backup was not from the same schedule with the generic backup ( in that case, newly restored generic resources were identified as restored in another session and were cleaned by the post restore operation )

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Restore
metadata:
  name: restore-acm-passive-sync
  namespace: open-cluster-management-backup
spec:
  cleanupBeforeRestore: CleanupRestored
  restoreSyncInterval: 5m
  syncRestoreWithNewBackups: true
  veleroCredentialsBackupName: latest
  veleroManagedClustersBackupName: skip
  veleroResourcesBackupName: latest
status:
  lastMessage: >-
    Velero restores have run to completion, restore will continue to sync with
    new backups
  phase: Enabled
  veleroCredentialsRestoreName: restore-acm-passive-sync-acm-credentials-schedule-20230615200051
  veleroGenericResourcesRestoreName: restore-acm-passive-sync-acm-resources-generic-schedule-20230615200051
  veleroResourcesRestoreName: restore-acm-passive-sync-acm-resources-schedule-20230615200051
```