### PR TITLE
backup multiclusterobservability under active data backup

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -117,6 +117,7 @@ var (
 		"hostfirmwaresettings.metal3.io",
 		"clustersync.hiveinternal.openshift.io",
 		"clusterimageset.hive.openshift.io",
+		"multiclusterobservability.observability.open-cluster-management.io",
 	}
 
 	// all backup resources, except secrets, configmaps and managed cluster activation resources


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-4225

Move MultiClusterObservability to the active resource set since this resource once restored on the restore hub creates all obs resources using the backed secrets and configmaps; as a result it creates PV and PVClaims
We don't want to have these resources created until the very end, when the passive cluster becomes active