### PR TITLE
remove MSA installNS on ManagedClusterAddOn

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -247,9 +247,7 @@ func prepareImportedClusters(ctx context.Context,
 			}
 
 			alreadyCreated := false
-			installNamespace := ""
 			for addon := range addons.Items {
-				installNamespace = addons.Items[addon].Spec.InstallNamespace
 				if addons.Items[addon].Name == msa_addon {
 					alreadyCreated = true
 					break
@@ -259,7 +257,7 @@ func prepareImportedClusters(ctx context.Context,
 				msaAddon := &addonv1alpha1.ManagedClusterAddOn{}
 				msaAddon.Name = msa_addon
 				msaAddon.Namespace = managedCluster.Name
-				msaAddon.Spec.InstallNamespace = installNamespace
+				// Not setting msaAddon.Spec.InstallNamespace - will leave default
 				labels := map[string]string{
 					msa_label: msa_service_name,
 				}

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -543,7 +543,16 @@ var _ = Describe("BackupSchedule controller", func() {
 			).Should(Equal(metav1.Duration{Duration: time.Hour * 72}))
 
 			// update schedule, it should NOT trigger velero schedules deletion
-			createdBackupSchedule.Spec.VeleroTTL = metav1.Duration{Duration: time.Hour * 150}
+			Eventually(func() error {
+				// Re-load createdBackupSchedule to avoid timing issues with the schedule controller updating it
+				// at the same time as this test
+				err := k8sClient.Get(ctx, backupLookupKey, &createdBackupSchedule)
+				if err != nil {
+					return err
+				}
+				createdBackupSchedule.Spec.VeleroTTL = metav1.Duration{Duration: time.Hour * 150}
+				return k8sClient.Update(context.Background(), &createdBackupSchedule, &client.UpdateOptions{})
+			}, timeout, interval).Should(Succeed())
 			Expect(
 				k8sClient.
 					Update(context.Background(), &createdBackupSchedule, &client.UpdateOptions{}),


### PR DESCRIPTION
Do not set spec.installNamespace on managed-serviceaccount ManagedClusterAddOn when creating it.

For: https://issues.redhat.com/browse/ACM-6967