### PR TITLE
Update upstream to golang 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
 
 WORKDIR /workspace
 # Copy the source files

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/cluster-backup-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/onsi/ginkgo/v2 v2.6.0


### PR DESCRIPTION
midstream repo is already building the downstream with golang 1.20

Downstream builds for release-2.6-2.9 are also using golang 1.20 - so will also update release-2.6, release-2.7, release-2.8 to golang 1.20