### PR TITLE
patch clusterDeployment with the disable-creation-webhook-for-dr label

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -702,12 +702,12 @@ func updateHiveResources(ctx context.Context,
 					// label already set
 					continue
 				}
+				logger.Info("Patching disable-creation-webhook-for-dr label on deployment " + clusterDeployment.Name)
+
 				patch := `[ { "op": "add", "path": "` + hive_label_path + `", "value": "true" } ]`
 				if _, err := dr.Namespace(clusterDeployment.GetNamespace()).Patch(ctx, clusterDeployment.GetName(),
 					types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
 					logger.Error(err, "cannot patch with hive label hive.openshift.io~1disable-creation-webhook-for-dr")
-				} else {
-					logger.Info("deployment patched with disable-creation-webhook-for-dr label " + clusterDeployment.Name)
 				}
 			}
 		}

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -119,7 +119,12 @@ func (r *BackupScheduleReconciler) prepareForBackup(
 		}
 	}
 
-	updateHiveResources(ctx, r.Client)
+	hiveDeploymentMapping, _ := mapper.RESTMapping(schema.GroupKind{
+		Group: "hive.openshift.io",
+		Kind:  "ClusterDeployment",
+	}, "")
+
+	updateHiveResources(ctx, r.Client, r.DynamicClient.Resource(hiveDeploymentMapping.Resource))
 	updateAISecrets(ctx, r.Client)
 	updateMetalSecrets(ctx, r.Client)
 
@@ -665,6 +670,7 @@ func updateMSASecretTimestamp(
 // prepare hive cluster claim and cluster pool
 func updateHiveResources(ctx context.Context,
 	c client.Client,
+	dr dynamic.NamespaceableResourceInterface,
 ) {
 	logger := log.FromContext(ctx)
 	// update secrets for clusterDeployments created by cluster claims
@@ -690,12 +696,14 @@ func updateHiveResources(ctx context.Context,
 				if labels == nil {
 					labels = make(map[string]string)
 				}
-				labels["hive.openshift.io/disable-creation-webhook-for-dr"] = "true"
-				clusterDeployment.SetLabels(labels)
-				msg := "update clusterDeployment " + clusterDeployment.Name
-				logger.Info(msg)
-				if err := c.Update(ctx, &clusterDeployment, &client.UpdateOptions{}); err == nil {
-					logger.Info("Updated clusterDeployment " + clusterDeployment.Name)
+				if labels["hive.openshift.io/disable-creation-webhook-for-dr"] == "" {
+					patch := `[ { "op": "add", "path": "/metadata/labels/hive.openshift.io~1disable-creation-webhook-for-dr", "value": "true" } ]`
+					if _, err := dr.Namespace(clusterDeployment.GetNamespace()).Patch(ctx, clusterDeployment.GetName(),
+						types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
+						logger.Error(err, "cannot patch with hive label hive.openshift.io~1disable-creation-webhook-for-dr")
+					} else {
+						logger.Info("deployment patched with disable-creation-webhook-for-dr label " + clusterDeployment.Name)
+					}
 				}
 			}
 		}

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -161,7 +161,7 @@ var _ = Describe("BackupSchedule controller", func() {
 						},
 					},
 					Size:       4,
-					BaseDomain: "dev06.red-chesterfield.com",
+					BaseDomain: "d.red-c.com",
 				},
 			},
 		}
@@ -180,7 +180,27 @@ var _ = Describe("BackupSchedule controller", func() {
 						Namespace: clusterPoolNSName,
 						PoolName:  clusterPoolNSName,
 					},
-					BaseDomain: "dev06.red-chesterfield.com",
+					BaseDomain: "d.red-c.com",
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "hive.openshift.io/v1",
+					Kind:       "ClusterDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      veleroNamespaceName,
+					Namespace: veleroNamespaceName,
+					Labels: map[string]string{
+						"hive.openshift.io/disable-creation-webhook-for-dr": "true",
+					},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterPoolRef: &hivev1.ClusterPoolReference{
+						Namespace: clusterPoolNSName + "1",
+						PoolName:  clusterPoolNSName + "1",
+					},
+					BaseDomain: "d.red-c.com",
 				},
 			},
 		}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8301

Issue:
Getting a webhook error when trying to update the ClusterDeployment and add the hive label used to bypass the claimed cluster deployment webhook validation which throws an error when the resource is recreated in a restore scenario
hive.openshift.io/disable-creation-webhook-for-dr: true

This work has been covered by this hive story

https://issues.redhat.com/browse/HIVE-1791
with this PR https://github.com/openshift/hive/pull/1729

This is the error we get now , trying to run a client.Update on the resource :
"admission webhook \"clusterdeploymentvalidators.admission.hive.openshift.io\" denied the request: ClusterDeployment.hive.openshift.io \"azr-pool-tn-cdfr7\" is invalid: spec.clusterMetadata: Invalid value: v1.ClusterMetadata{ClusterID:\"e896b78c-de90-49d0-af2d-04f4db2dd550\", InfraID:\"azr-pool-tn-cdfr7-gcmcb\", AdminKubeconfigSecretRef:v1.LocalObjectReference
{Name:\"azr-pool-tn-cdfr7-0-58dgx-admin-kubeconfig\"}
, AdminPasswordSecretRef*v1.LocalObjectReference)(0xc001027580), Platform*v1.ClusterPlatformMetadata)(nil)}: field is immutable"}

The fix:
Patch the resource instead of running the client.Update command
	hive_label_path       = "/metadata/labels/hive.openshift.io~1disable-creation-webhook-for-dr"

				patch := `[ { "op": "add", "path": "` + hive_label_path + `", "value": "true" } ]`
				if _, err := dr.Namespace(clusterDeployment.GetNamespace()).Patch(ctx, clusterDeployment.GetName(),
					types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
					logger.Error(err, "cannot patch with hive label hive.openshift.io~1disable-creation-webhook-for-dr")
				}
