### PR TITLE
create role binding for custom and default ns

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -8,6 +8,7 @@ import (
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 )
 
@@ -51,6 +52,22 @@ func createSecret(name string, ns string,
 	}
 
 	return secret
+
+}
+
+func createMWork(name string, ns string) *workv1.ManifestWork {
+	mwork := &workv1.ManifestWork{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "work.open-cluster-management.io",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+
+	return mwork
 
 }
 

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -521,13 +521,13 @@ func deleteCustomManifestWork(
 ) {
 	logger := log.FromContext(ctx)
 
-	custom_mwork := &workv1.ManifestWork{}
+	custommwork := &workv1.ManifestWork{}
 	if err := c.Get(ctx, types.NamespacedName{Name: mworkName + mwork_custom_282,
-		Namespace: namespace}, custom_mwork); err == nil {
+		Namespace: namespace}, custommwork); err == nil {
 
 		// delete the resource
 		logger.Info("Deleting manifest work %s in ns %s", mwork_custom_282, namespace)
-		if err := c.Delete(ctx, custom_mwork); err != nil {
+		if err := c.Delete(ctx, custommwork); err != nil {
 			logger.Error(err, "Failed to delete manifest work")
 		}
 	}

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -556,9 +556,11 @@ func createManifestWork(
 					*manifest,
 				}
 
-				logger.Info(fmt.Sprintf("Attempt to create ManifestWork %s in ns %s, for ns=%s", mwork, namespace, installNamespace))
+				logger.Info(fmt.Sprintf("Attempt to create ManifestWork %s in ns %s, for ns=%s",
+					mwork, namespace, installNamespace))
 				if err := c.Create(ctx, manifestWork, &client.CreateOptions{}); err == nil {
-					logger.Info(fmt.Sprintf("Created ManifestWork %s in ns %s for ns=%s", mwork, namespace, installNamespace))
+					logger.Info(fmt.Sprintf("Created ManifestWork %s in ns %s for ns=%s",
+						mwork, namespace, installNamespace))
 				} else {
 					logger.Error(err, "Failed to create ManifestWork")
 				}

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -44,9 +44,9 @@ import (
 )
 
 const (
-	// manifest work prefix used and created in 2.8.2
+	// manifest work suffix used and created in 2.8.2
 	mwork_custom_282 = "-custom"
-	// manifest work prefix used and created 2.8.3 and onward
+	// manifest work suffix used and created 2.8.3 and onward
 	mwork_custom_283      = "-custom-2"
 	hive_label            = "hive.openshift.io/disable-creation-webhook-for-dr"
 	hive_label_path       = "/metadata/labels/hive.openshift.io~1disable-creation-webhook-for-dr"

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -44,6 +44,10 @@ import (
 )
 
 const (
+	// manifest work prefix used and created in 2.8.2
+	mwork_custom_282 = "-custom"
+	// manifest work prefix used and created 2.8.3 and onward
+	mwork_custom_283      = "-custom-2"
 	hive_label            = "hive.openshift.io/disable-creation-webhook-for-dr"
 	hive_label_path       = "/metadata/labels/hive.openshift.io~1disable-creation-webhook-for-dr"
 	msa_addon             = "managed-serviceaccount"
@@ -364,13 +368,20 @@ func createMSA(
 
 	logger := log.FromContext(ctx)
 
+	// delete manifest works prefixed with -custom
+	// they are created in 2.8.2 and have a rolebinding overlapping with the default ns
+	// get rid of them; will be relaced by the -custom-2 manifest works
+	deleteCustomManifestWork(ctx, c, managedClusterName, manifest_work_name)
+
 	if name == msa_service_name {
 		// attempt to create ManifestWork to push the role binding, if not created already
 		createManifestWork(ctx, c, managedClusterName, name,
 			manifest_work_name_binding_name, msa_service_name, manifest_work_name, installNamespace)
 
 		if installNamespace != defaultAddonNS {
-			// attempt to create the ManifestWork in the default NS
+			// attempt to create the ManifestWork in the default NS even if the installNamespace is set to custom ns
+			// this is to cover the case in 2.9 and onward when the user manually sets the installNamespace to a custom value
+			// in this version, the MSA framework ignores the custom value and creates the MSA in the addon default NS
 			createManifestWork(ctx, c, managedClusterName, name,
 				manifest_work_name_binding_name, msa_service_name, manifest_work_name, defaultAddonNS)
 		}
@@ -407,7 +418,9 @@ func createMSA(
 				manifest_work_name_binding_name_pair, msa_service_name_pair, manifest_work_name_pair, installNamespace)
 
 			if installNamespace != defaultAddonNS {
-				// attempt to create the ManifestWork in the default NS
+				// attempt to create the ManifestWork in the default NS even if the installNamespace is set to custom ns
+				// this is to cover the case in 2.9 and onward when the user manually sets the installNamespace to a custom value
+				// in this version, the MSA framework ignores the custom value and creates the MSA in the addon default NS
 				createManifestWork(ctx, c, managedClusterName, name,
 					manifest_work_name_binding_name_pair, msa_service_name_pair, manifest_work_name_pair, defaultAddonNS)
 			}
@@ -500,6 +513,27 @@ func updateMSAToken(
 }
 
 // create manifest work to push the import user role binding to the managed cluster
+func deleteCustomManifestWork(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	mworkName string,
+) {
+	logger := log.FromContext(ctx)
+
+	custom_mwork := &workv1.ManifestWork{}
+	if err := c.Get(ctx, types.NamespacedName{Name: mworkName + mwork_custom_282,
+		Namespace: namespace}, custom_mwork); err == nil {
+
+		// delete the resource
+		logger.Info("Deleting manifest work %s in ns %s", mwork_custom_282, namespace)
+		if err := c.Delete(ctx, custom_mwork); err != nil {
+			logger.Error(err, "Failed to delete manifest work")
+		}
+	}
+}
+
+// create manifest work to push the import user role binding to the managed cluster
 func createManifestWork(
 	ctx context.Context,
 	c client.Client,
@@ -515,11 +549,14 @@ func createManifestWork(
 	mwork := mworkName
 	mworkBinding := mworkbindingName
 	if installNamespace != defaultAddonNS {
+		// to be used for the case when the MSA uses a custom ns, in 2.8 and 2.7
+		// starting with 2.9 and onwards the installNamespace for the MSA is ignored
+		// so in this cases the custom manifest work is not going to be used
+
 		// use this to create a custom manifest work name
-		// to be used for the case when the MSA uses a custom ns
-		mwork = mworkName + "-custom"
+		mwork = mworkName + mwork_custom_283
 		// use a different role binding name for the custom ns
-		mworkBinding = mworkbindingName + "-custom"
+		mworkBinding = mworkbindingName + mwork_custom_283
 	}
 
 	manifestWorkList := &workv1.ManifestWorkList{}

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -63,6 +63,11 @@ func Test_createMSA(t *testing.T) {
 		t.Errorf("cannot create secret %s", err.Error())
 	}
 
+	if err := k8sClient1.Create(context.Background(),
+		createMWork(manifest_work_name+mwork_custom_282, namespace)); err != nil {
+		t.Errorf("cannot create mwork %s", err.Error())
+	}
+
 	obj1 := &unstructured.Unstructured{}
 	obj1.SetUnstructuredContent(map[string]interface{}{
 		"apiVersion": "authentication.open-cluster-management.io/v1beta1",

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -257,15 +257,15 @@ func Test_createMSA(t *testing.T) {
 
 			}
 
-			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name + "-custom",
+			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name + "-custom-2",
 				Namespace: tt.args.managedCluster}, work); err != nil {
 				t.Errorf("cannot get manifestwork %s ", err.Error())
 			} else {
-				str := `"kind":"ClusterRoleBinding","metadata":{"name":"managedserviceaccount-import-custom"}`
+				str := `"kind":"ClusterRoleBinding","metadata":{"name":"managedserviceaccount-import-custom-2"}`
 				rawData := string(work.Spec.Workload.Manifests[0].Raw[:])
 
 				if !strings.Contains(rawData, str) {
-					t.Errorf("Cluster role binding should be %v for manifest %v but is %v", "managedserviceaccount-import-custom", work.Name, rawData)
+					t.Errorf("Cluster role binding should be %v for manifest %v but is %v", "managedserviceaccount-import-custom-2", work.Name, rawData)
 				}
 
 				strserviceaccount := `{"kind":"ServiceAccount","name":"auto-import-account","namespace":"managed1"}`
@@ -273,6 +273,12 @@ func Test_createMSA(t *testing.T) {
 					t.Errorf("ServiceAccount should be %v for manifest %v, but is %v", strserviceaccount, work.Name, rawData)
 				}
 
+			}
+
+			// this should be deleted
+			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name + mwork_custom_282,
+				Namespace: tt.args.managedCluster}, work); err == nil {
+				t.Errorf("this manifest should no longer exist ! %s ", err.Error())
 			}
 
 		})

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -48,6 +50,7 @@ func Test_createMSA(t *testing.T) {
 	cfg, _ := testEnv.Start()
 	scheme1 := runtime.NewScheme()
 	corev1.AddToScheme(scheme1)
+	workv1.AddToScheme(scheme1)
 	k8sClient1, _ := client.New(cfg, client.Options{Scheme: scheme1})
 
 	namespace := "managed1"
@@ -234,6 +237,44 @@ func Test_createMSA(t *testing.T) {
 			if secretsUpdated != tt.secretsUpdated {
 				t.Errorf("createMSA() returns secretsUpdated = %v, want %v", secretsUpdated, tt.secretsUpdated)
 			}
+
+			work := &workv1.ManifestWork{}
+			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name,
+				Namespace: tt.args.managedCluster}, work); err != nil {
+				t.Errorf("cannot get manifestwork %s ", err.Error())
+			} else {
+				rawData := string(work.Spec.Workload.Manifests[0].Raw[:])
+
+				str := `"kind":"ClusterRoleBinding","metadata":{"name":"managedserviceaccount-import"}`
+				if !strings.Contains(rawData, str) {
+					t.Errorf("Cluster role binding should be %v for manifest %v but is %v", "managedserviceaccount-import", work.Name, rawData)
+				}
+
+				strserviceaccount := `{"kind":"ServiceAccount","name":"auto-import-account","namespace":"open-cluster-management-agent-addon"}`
+				if !strings.Contains(rawData, strserviceaccount) {
+					t.Errorf("ServiceAccount should be %v for manifest %v, but is %v", strserviceaccount, work.Name, rawData)
+				}
+
+			}
+
+			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name + "-custom",
+				Namespace: tt.args.managedCluster}, work); err != nil {
+				t.Errorf("cannot get manifestwork %s ", err.Error())
+			} else {
+				str := `"kind":"ClusterRoleBinding","metadata":{"name":"managedserviceaccount-import-custom"}`
+				rawData := string(work.Spec.Workload.Manifests[0].Raw[:])
+
+				if !strings.Contains(rawData, str) {
+					t.Errorf("Cluster role binding should be %v for manifest %v but is %v", "managedserviceaccount-import-custom", work.Name, rawData)
+				}
+
+				strserviceaccount := `{"kind":"ServiceAccount","name":"auto-import-account","namespace":"managed1"}`
+				if !strings.Contains(rawData, strserviceaccount) {
+					t.Errorf("ServiceAccount should be %v for manifest %v, but is %v", strserviceaccount, work.Name, rawData)
+				}
+
+			}
+
 		})
 	}
 	testEnv.Stop()


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8348

https://issues.redhat.com/browse/ACM-8263

Issue:
1. in 2.8.2 For MSA accounts created in a ns different than the default addon, we create a custom ManifestWork to create a RoleBinding for the ServiceAccount in that ns

The issue is that the RoleBinding has the same name as the one created by the initial ManifestWork and since this is a global resource, both ManifestWork owns it. Each ManifestWork keep updating the RoleBinding 

 
```
oc get clusterrolebinding managedserviceaccount-import -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
creationTimestamp: "2023-10-25T15:42:54Z"
name: managedserviceaccount-import
ownerReferences:

apiVersion: work.open-cluster-management.io/v1
kind: AppliedManifestWork
name: 13583c9e64c6bd8e94c94f7aa0e5a3b873c8033fc07c1f2ceb7c6b5da3056750-addon-managed-serviceaccount-import
uid: b5fcf244-e461-404a-88c7-4c4aeba5db57
apiVersion: work.open-cluster-management.io/v1
kind: AppliedManifestWork
name: 13583c9e64c6bd8e94c94f7aa0e5a3b873c8033fc07c1f2ceb7c6b5da3056750-addon-managed-serviceaccount-import-custom
uid: c0476c37-c3b0-4184-bedd-e9ffb10e131c
resourceVersion: "49530"
uid: 597859e7-ce78-43dc-8b65-b038492751bc
roleRef:
apiGroup: rbac.authorization.k8s.io
kind: ClusterRole
name: klusterlet-bootstrap-kubeconfig
subjects:
kind: ServiceAccount
name: auto-import-account
namespace: open-cluster-management-addon-observability
```

2. second issue for 2.9 : even when a MSA is to use a custom ns, the framework ignores this value and puts in into the default addon ns. The backup operator code is not aware of this change and it creates the custom ManifestWork, which creates the RoleBinding for the custom ns, instead of the default one 

Fixes:
- Delete the custom Manifest work if exists
- if the MSA sets a custom ns, create a custom-2 suffixed ManifestWork ; use the same name for the RoleBinding in the workload so it doesn't collide with the one created for the addon ns
- Even if the MSA is set to a custom ns, to account for the framework fixes in 2.9, we also create a ManifestWork for the default addon ns