### PR TITLE
delete mwork for pair MSA

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -372,6 +372,7 @@ func createMSA(
 	// they are created in 2.8.2 and have a rolebinding overlapping with the default ns
 	// get rid of them; will be relaced by the -custom-2 manifest works
 	deleteCustomManifestWork(ctx, c, managedClusterName, manifest_work_name)
+	deleteCustomManifestWork(ctx, c, managedClusterName, manifest_work_name_pair)
 
 	if name == msa_service_name {
 		// attempt to create ManifestWork to push the role binding, if not created already

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -68,6 +68,11 @@ func Test_createMSA(t *testing.T) {
 		t.Errorf("cannot create mwork %s", err.Error())
 	}
 
+	if err := k8sClient1.Create(context.Background(),
+		createMWork(manifest_work_name_pair+mwork_custom_282, namespace)); err != nil {
+		t.Errorf("cannot create mwork %s", err.Error())
+	}
+
 	obj1 := &unstructured.Unstructured{}
 	obj1.SetUnstructuredContent(map[string]interface{}{
 		"apiVersion": "authentication.open-cluster-management.io/v1beta1",
@@ -283,7 +288,12 @@ func Test_createMSA(t *testing.T) {
 			// this should be deleted
 			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name + mwork_custom_282,
 				Namespace: tt.args.managedCluster}, work); err == nil {
-				t.Errorf("this manifest should no longer exist ! %s ", err.Error())
+				t.Errorf("this manifest should no longer exist ! %v ", manifest_work_name+mwork_custom_282)
+			}
+
+			if err := k8sClient1.Get(context.Background(), types.NamespacedName{Name: manifest_work_name_pair + mwork_custom_282,
+				Namespace: tt.args.managedCluster}, work); err == nil {
+				t.Errorf("this manifest should no longer exist ! %v ", manifest_work_name_pair+mwork_custom_282)
 			}
 
 		})


### PR DESCRIPTION
related to PR https://github.com/stolostron/cluster-backup-operator/pull/443

adding a deletion of the custom manifestwork for the pair MSA , managedserviceaccount-import-pair 
This pair MSA is created at half time the lifespan of the initial MSA to increase the likelihood of a valid MSA token being available with any backup

oc get ServiceAccount -A | grep auto-import-account
open-cluster-management-addon-observability        auto-import-account                                1         11d
open-cluster-management-addon-observability        auto-import-account-pair                           1         6d2h