### PR TITLE
OADP 1.3 CRD updates

### DIFF
--- a/config/crd/bases/velero.io_backups.yaml
+++ b/config/crd/bases/velero.io_backups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: backups.velero.io
 spec:
@@ -39,6 +39,11 @@ spec:
                 description: CSISnapshotTimeout specifies the time used to wait for
                   CSI VolumeSnapshot status turns to ReadyToUse during creation, before
                   returning error as timeout. The default value is 10 minute.
+                type: string
+              datamover:
+                description: DataMover specifies the data mover to be used by the
+                  backup. If DataMover is "" or "velero", the built-in data mover
+                  will be used.
                 type: string
               defaultVolumesToFsBackup:
                 description: DefaultVolumesToFsBackup specifies whether pod volume
@@ -173,6 +178,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           description: Name is the name of this hook.
                           type: string
@@ -358,6 +364,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               metadata:
                 properties:
                   labels:
@@ -418,6 +425,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 nullable: true
                 type: array
               orderedResources:
@@ -450,6 +458,12 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-map-type: atomic
+              snapshotMoveData:
+                description: SnapshotMoveData specifies whether snapshot data should
+                  be moved
+                nullable: true
+                type: boolean
               snapshotVolumes:
                 description: SnapshotVolumes specifies whether to take snapshots of
                   any PV's referenced in the set of objects included in the Backup.
@@ -593,5 +607,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/velero.io_backupstoragelocations.yaml
+++ b/config/crd/bases/velero.io_backupstoragelocations.yaml
@@ -1,10 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: backupstoragelocations.velero.io
 spec:
@@ -92,6 +90,7 @@ spec:
                 required:
                 - key
                 type: object
+                x-kubernetes-map-type: atomic
               default:
                 description: Default indicates this location is the default backup
                   storage location.
@@ -177,5 +176,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/velero.io_deletebackuprequests.yaml
+++ b/config/crd/bases/velero.io_deletebackuprequests.yaml
@@ -1,10 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: deletebackuprequests.velero.io
 spec:
@@ -77,5 +75,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/velero.io_restores.yaml
+++ b/config/crd/bases/velero.io_restores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: restores.velero.io
 spec:
@@ -55,7 +55,7 @@ spec:
                 type: array
               existingResourcePolicy:
                 description: ExistingResourcePolicy specifies the restore behavior
-                  for the kubernetes resource to be restored
+                  for the Kubernetes resource to be restored
                 nullable: true
                 type: string
               hooks:
@@ -145,6 +145,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           description: Name is the name of this hook.
                           type: string
@@ -201,6 +202,7 @@ spec:
                                       to be added to a pod during its restore.
                                     items:
                                       type: object
+                                      x-kubernetes-preserve-unknown-fields: true
                                     type: array
                                     x-kubernetes-preserve-unknown-fields: true
                                   timeout:
@@ -287,6 +289,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               namespaceMapping:
                 additionalProperties:
                   type: string
@@ -348,6 +351,7 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
                 nullable: true
                 type: array
               preserveNodePorts:
@@ -355,6 +359,28 @@ spec:
                   from backup.
                 nullable: true
                 type: boolean
+              resourceModifier:
+                description: ResourceModifier specifies the reference to JSON resource
+                  patches that should be applied to resources before restoration.
+                nullable: true
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
               restorePVs:
                 description: RestorePVs specifies whether to restore all included
                   PVs from snapshot
@@ -476,5 +502,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/velero.io_schedules.yaml
+++ b/config/crd/bases/velero.io_schedules.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: schedules.velero.io
 spec:
@@ -69,6 +69,11 @@ spec:
                     description: CSISnapshotTimeout specifies the time used to wait
                       for CSI VolumeSnapshot status turns to ReadyToUse during creation,
                       before returning error as timeout. The default value is 10 minute.
+                    type: string
+                  datamover:
+                    description: DataMover specifies the data mover to be used by
+                      the backup. If DataMover is "" or "velero", the built-in data
+                      mover will be used.
                     type: string
                   defaultVolumesToFsBackup:
                     description: DefaultVolumesToFsBackup specifies whether pod volume
@@ -204,6 +209,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             name:
                               description: Name is the name of this hook.
                               type: string
@@ -394,6 +400,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                   metadata:
                     properties:
                       labels:
@@ -454,6 +461,7 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     nullable: true
                     type: array
                   orderedResources:
@@ -486,6 +494,12 @@ spec:
                     - kind
                     - name
                     type: object
+                    x-kubernetes-map-type: atomic
+                  snapshotMoveData:
+                    description: SnapshotMoveData specifies whether snapshot data
+                      should be moved
+                    nullable: true
+                    type: boolean
                   snapshotVolumes:
                     description: SnapshotVolumes specifies whether to take snapshots
                       of any PV's referenced in the set of objects included in the
@@ -547,5 +561,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
Updating Velero CRDs to version v1.12.1 used for OADP v1.3.0
OADP repo:  https://github.com/openshift/oadp-operator/tree/oadp-1.3/bundle/manifests
Jira iisue: https://issues.redhat.com/browse/ACM-8865