### PR TITLE
exclude CRDs from restore

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -741,6 +741,8 @@ func setOptionalProperties(
 		veleroRestore.Spec.IncludeClusterResources = &clusterResource
 	}
 
+	veleroRestore.Spec.ExcludedResources = append(veleroRestore.Spec.ExcludedResources, "CustomResourceDefinition")
+
 	// update existing resources if part of the new backup
 	veleroRestore.Spec.ExistingResourcePolicy = veleroapi.PolicyTypeUpdate
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8904

https://issues.redhat.com/browse/ACM-8870

Exclude CRDs when restoring a backup using the `Restore.Spec.ExcludedResources` option