### PR TITLE
activation resources may not be restored if sync restore

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -595,12 +595,12 @@ func retrieveRestoreDetails(
 
 	restoreLength := len(veleroBackupNames) - 1 // ignore validation backup
 	if restoreOnlyManagedClusters {
-		restoreLength = 2 // will get only managed clusters and generic resources
+		restoreLength = 3 // will get only managed clusters, generic resources and credentials
 	}
 	restoreKeys := make([]ResourceType, 0, restoreLength)
 	for key := range veleroBackupNames {
 		if key == ValidationSchedule ||
-			(restoreOnlyManagedClusters && !(key == ManagedClusters || key == ResourcesGeneric)) {
+			(restoreOnlyManagedClusters && !(key == ManagedClusters || key == ResourcesGeneric || key == Credentials)) {
 			// ignore validation backup; this is used for the policy
 			// to validate that there are backups schedules enabled
 			// also ignore all but managed clusters when only this is restored

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -120,7 +120,8 @@ func cleanupDeltaResources(
 		backupName, veleroBackup := getBackupInfoFromRestore(ctx, c,
 			acmRestore.Status.VeleroCredentialsRestoreName, acmRestore.Namespace)
 		cleanupDeltaForCredentials(ctx, c,
-			backupName, veleroBackup, acmRestore.Spec.CleanupBeforeRestore, *acmRestore.Spec.VeleroManagedClustersBackupName != skipRestoreStr)
+			backupName, veleroBackup, acmRestore.Spec.CleanupBeforeRestore,
+			*acmRestore.Spec.VeleroManagedClustersBackupName != skipRestoreStr)
 
 		// clean up resources and generic resources
 		cleanupDeltaForResourcesBackup(ctx, c, restoreOptions, acmRestore)

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -1375,7 +1375,7 @@ func Test_cleanupDeltaForCredentials(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cleanupDeltaForCredentials(tt.args.ctx, tt.args.c,
-				tt.args.backupName, tt.args.veleroBackup, tt.args.cleanupType)
+				tt.args.backupName, tt.args.veleroBackup, tt.args.cleanupType, false)
 		})
 
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9475

When the restore passive operation is being used, when the activation data is restored by updating the veleroManagedClustersBackupName: latest on this resource, the activation resources might not be restored.

This is because the activation restore is trying to use the same velero restore as the sync restore, unless a new backup has been created when the activation is started.

https://github.com/stolostron/cluster-backup-operator/blob/main/config/samples/cluster_v1beta1_restore_passive_sync.yaml

Version-Release number of selected component (if applicable):
How reproducible:
Always with the steps below

Steps to Reproduce:

1. Backup hub resources and create at least one resource R with this label : cluster.open-cluster-management.io/backup: cluster-activation. This resource should be restored at activation time.  
2. On a new hub, run a restore passive with sync operation , using this sample https://github.com/stolostron/cluster-backup-operator/blob/main/config/samples/cluster_v1beta1_restore_passive_sync.yaml
3. Verify that the resource are restored , with the exception of this R resource. This is the expected output
4. Without waiting for a new backup to be generated, run the activation step : on the Restore resource created at step 2, set veleroManagedClustersBackupName: latest
5.  This should result in restoring resource R. This is not happening because no new backup was created, the restore files names are generated using the backup name, so a new restore will not be executed 

Actual results:
R is not restored at step 5

Expected results:
R should be restored at step 5

Changes:
- allow configmap and secrets to be restored at activation time using the `cluster.open-cluster-management.io/backup: cluster-activation` label
- if the restore is using the `syncRestoreWithNewBackups: true` option, when the managed clusters activation data is set to be restored , which is the final step, ( `veleroManagedClustersBackupName: latest` ), then the activation resources are restored in a velero restore file using -active as a prefix. This makes sure that this restore file can be created, since it is different from the name of the restore file already created by the sync operation ( for credentials and generic backup, which are the backups restoring activation resources and are also restored during the sync process )