### PR TITLE
add wait for restore when pvc need to be created first

### DIFF
--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -524,7 +524,7 @@ func (r *RestoreReconciler) waitForPVCHooksOnRestore(
 			Namespace: acmRestore.Namespace,
 		}
 		if err := r.Client.Get(ctx, lookupKey, restore); err != nil {
-			return false, ""
+			return true, "Waiting on restore"
 		}
 
 		if restore.Status.Phase == "" ||

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -191,7 +191,8 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	isValidSync, msg := isValidSyncOptions(restore)
 	sync := isValidSync && restore.Status.Phase == v1beta1.RestorePhaseEnabled
-	// If any pvcs were created on the backup hub using the backup-pvc label, wait for the pvc to be created by the pvc configmap
+	// If any pvcs were created on the backup hub using the backup-pvc label,
+	// wait for the pvc to be created by the pvc configmap
 	// the config map is restored with the credentials backup, which is the first backup to be restored
 	// wait for the pvc when only the credentials backup was created and the restore is not set to sync backup data
 	isCredsClsOnActiveSteps := len(veleroRestoreList.Items) == 1 && restore.Status.Phase == v1beta1.RestorePhaseStarted

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -402,7 +402,9 @@ func (r *RestoreReconciler) initVeleroRestores(
 		waitForPVC := updateLabelsForActiveResources(restore, key, veleroRestoresToCreate)
 		err := r.Create(ctx, veleroRestoresToCreate[key], &client.CreateOptions{})
 		// check if needed to wait for pvcs to be created before the app data is restored
-		if shouldWait, waitMsg := r.waitForPVCHooksOnRestore(ctx, waitForPVC, veleroRestoresToCreate[key].Name, restore); shouldWait {
+		if shouldWait, waitMsg := r.waitForPVCHooksOnRestore(ctx,
+			waitForPVC,
+			veleroRestoresToCreate[key].Name, restore); shouldWait {
 			// some PVCs were not created yet, wait for them
 			return true, waitMsg, nil
 		}

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -521,14 +521,14 @@ func (r *RestoreReconciler) waitForPVCHooksOnRestore(
 		Name:      restoreName,
 		Namespace: acmRestore.Namespace,
 	}
-	if err := r.Client.Get(ctx, lookupKey, restore); err != nil {
-		return false, ""
+
+	status := veleroapi.RestorePhaseNew
+	if err := r.Client.Get(ctx, lookupKey, restore); err == nil {
+		status = restore.Status.Phase
 	}
 
-	if restore.Status.Phase == "" ||
-		restore.Status.Phase == veleroapi.RestorePhaseNew ||
-		restore.Status.Phase == veleroapi.RestorePhaseInProgress {
-		// look for the list of PVCs, wait firt for the backup to complete
+	if status == "" || status == veleroapi.RestorePhaseNew || status == veleroapi.RestorePhaseInProgress {
+		// look for the list of PVCs, wait first for the backup to complete
 		restoreLogger.Info("Exit waitForPVCHooksOnRestore wait, restore not completed")
 		return true, "waiting for restore to complete " + restoreName
 	}

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -554,14 +554,16 @@ func (r *RestoreReconciler) processRestoreWait(
 				Name:      pvcName,
 				Namespace: pvcNS,
 			}
+			restoreLogger.Info(fmt.Sprintf("Check if PVC exists %s:%s", pvcNS, pvcName))
 			if errPVC := r.Client.Get(ctx, lookupKey, pvc); errPVC != nil {
 				restoreLogger.Info(fmt.Sprintf("PVC not found %s:%s", pvcNS, pvcName))
 				pvcs = append(pvcs, pvcName+":"+pvcNS)
 			}
-
 		}
-		restoreLogger.Info("Exit processRestoreWait, wait on PVCs: " + strings.Join(pvcs, ", "))
-		return len(pvcs) > 0, "waiting for PVC " + strings.Join(pvcs, ", ")
+		if len(pvcs) > 0 {
+			restoreLogger.Info("Exit processRestoreWait, PVCs not found : " + strings.Join(pvcs, ", "))
+			return true, "waiting for PVC " + strings.Join(pvcs, ", ")
+		}
 	}
 
 	restoreLogger.Info("Exit processRestoreWait with no wait")


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9503


When PVCs are backed up and restored using the volsync policy https://github.com/open-cluster-management-io/policy-collection/blob/main/community/CM-Configuration-Management/acm-volsync-hub-backup/README.md
we need to have a hook on the hub restore to allow the PVCs to be created by the volsync ReplicationDestination resource before the apps using that PVC is created. If this is not happening, the app uses the PVC before the PVC snapshot has been created and because of this it will corrupt the data
 
These are the details behind this approach:
1. all app resources which need to connect to the PVC should have the 
cluster.open-cluster-management.io/backup: cluster-activation label set so they are restored at the very end, when the managed clusters data is restored
2. the change with the task
	•	the restore backup checks if this is an activation restore stage; if this is the case, waits on the credentials restore to complete ( this is always restored first ),
	•	then looks for any restored configMap with this label `cluster.open-cluster-management.io/backup-pvc: {{ $pvc.metadata.name }}`; the volsync policy creates these resources on the backup hub and backs them up. They reflect the PVCs that would expect to be restored by the volsync policy first, because they were created by it. If any of these ConfigMaps are found, the restore waits until the corresponding PVCs are created on the restore hub. Basically waits for the volsync policy to create the ReplicationDestination which in turn creates the PVC. After this, the restore resumes since it's safe now for the app resource to access the PVC.
	◦	If any issues with the volsync policy or the ReplicationDestination, the restore waits until this is fixed - it is to allow the user to fix the problem : user forgot to install the volsync policy on the restore hub or there is issues with the secret, etc. 
	◦	To get out of this wait ,
	▪	you either have a successful volsync policy which creates a ReplicationDestination and the PVC
	▪	you manually remove the ConfigMaps keeping the restore in waiting  if you don't want to use the policy - so you are on your own .. PVC will not be restored by volsync
	▪	Or you manually create the PVC to let the restore get through - this and the item above is a workaround if something is not properly setup or you can't / don't want to use the volsync policy
