### PR TITLE
wait for pvc when only creds files were restored

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -268,6 +268,11 @@ func (b *RestoreHelper) backupName(name string) *RestoreHelper {
 	return b
 }
 
+func (b *RestoreHelper) scheduleName(name string) *RestoreHelper {
+	b.object.Spec.ScheduleName = name
+	return b
+}
+
 func (b *RestoreHelper) phase(phase veleroapi.RestorePhase) *RestoreHelper {
 	b.object.Status.Phase = phase
 	return b

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
@@ -88,6 +90,32 @@ func createConfigMap(name string, ns string,
 	}
 
 	return cmap
+
+}
+
+func createPVC(name string, ns string) *corev1.PersistentVolumeClaim {
+
+	pvc := &corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				"ReadWriteOnce",
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+	return pvc
 
 }
 

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -470,8 +470,8 @@ func (r *RestoreReconciler) initVeleroRestores(
 		}
 		// check if needed to wait for pvcs to be created before the app data is restored
 		if isCredsClsOnActiveStep {
-			if shouldWait, waitMsg := processRestoreWait(r.Client, ctx,
-				veleroRestoresToCreate[key].Name, restore); shouldWait {
+			if shouldWait, waitMsg := processRestoreWait(ctx, r.Client,
+				veleroRestoresToCreate[key].Name, restore.Namespace); shouldWait {
 				// some PVCs were not created yet, wait for them
 				return true, waitMsg, nil
 			}
@@ -546,10 +546,10 @@ func updateLabelsForActiveResources(
 // then verify if the PVC have been created and wait for the
 // PVC to be created by the backup-pvc policy
 func processRestoreWait(
-	c client.Client,
 	ctx context.Context,
+	c client.Client,
 	restoreName string,
-	acmRestore *v1beta1.Restore,
+	restoreNamespace string,
 ) (bool, string) {
 
 	restoreLogger := log.FromContext(ctx)
@@ -558,7 +558,7 @@ func processRestoreWait(
 	restore := &veleroapi.Restore{}
 	lookupKey := types.NamespacedName{
 		Name:      restoreName,
-		Namespace: acmRestore.Namespace,
+		Namespace: restoreNamespace,
 	}
 
 	status := veleroapi.RestorePhaseNew

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -564,7 +564,6 @@ func (r *RestoreReconciler) processRestoreWait(
 	if status == "" || status == veleroapi.RestorePhaseNew || status == veleroapi.RestorePhaseInProgress {
 		// look for the list of PVCs, wait first for the backup to complete
 		restoreLogger.Info("Exit processRestoreWait wait, restore not completed")
-		fmt.Println("\nStudent1:", restoreName)
 		return true, "waiting for restore to complete " + restoreName
 	}
 

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -243,6 +243,13 @@ func isPVCInitializationStep(
 	acmRestore *v1beta1.Restore,
 	veleroRestoreList veleroapi.RestoreList,
 ) bool {
+
+	if acmRestore.Spec.SyncRestoreWithNewBackups && *acmRestore.Spec.VeleroManagedClustersBackupName != skipRestoreStr {
+		// this is a sync restore where the managed cluster restore was requested
+		// this must be the activation step
+		return true
+	}
+
 	if len(veleroRestoreList.Items) == 0 || acmRestore.Status.Phase != v1beta1.RestorePhaseStarted {
 		// should be at least one velero restore created by this acmRestore and the acmRestore phase should be 'Started'
 		return false
@@ -557,6 +564,7 @@ func (r *RestoreReconciler) processRestoreWait(
 	if status == "" || status == veleroapi.RestorePhaseNew || status == veleroapi.RestorePhaseInProgress {
 		// look for the list of PVCs, wait first for the backup to complete
 		restoreLogger.Info("Exit processRestoreWait wait, restore not completed")
+		fmt.Println("\nStudent1:", restoreName)
 		return true, "waiting for restore to complete " + restoreName
 	}
 

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1484,3 +1484,125 @@ func Test_isPVCInitializationStep(t *testing.T) {
 		})
 	}
 }
+
+func Test_processRestoreWait(t *testing.T) {
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, _ := testEnv.Start()
+	k8sClient1, _ := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+
+	type args struct {
+		ctx              context.Context
+		c                client.Client
+		restoreName      string
+		restoreNamespace string
+		veleroRestore    veleroapi.Restore
+		pvMap            corev1.ConfigMap
+		pvc              corev1.PersistentVolumeClaim
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "no velero restore found for restoreName, wait",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				restoreName:      "creds-restore-name",
+				restoreNamespace: "default",
+				veleroRestore:    *createRestore("creds-restore-name-1", "default").object,
+				pvMap:            *createConfigMap("some-other-map-1", "default", nil),
+				pvc:              *createPVC("mongo-storage-1", "default"),
+			},
+			want: true,
+		},
+		{
+			name: "velero restore found but status is not completed, so wait",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				restoreName:      "creds-restore-name-2",
+				restoreNamespace: "default",
+				veleroRestore:    *createRestore("creds-restore-name-2", "default").object,
+				pvMap:            *createConfigMap("some-other-map-2", "default", nil),
+				pvc:              *createPVC("mongo-storage-2", "default"),
+			},
+			want: true,
+		},
+		{
+			name: "velero restore found and status is completed, no wait bc no config map",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				restoreName:      "creds-restore-name-3",
+				restoreNamespace: "default",
+				veleroRestore:    *createRestore("creds-restore-name-3", "default").phase("Completed").object,
+				pvMap:            *createConfigMap("some-other-map-3", "default", nil),
+				pvc:              *createPVC("mongo-storage-3", "default"),
+			},
+			want: false,
+		},
+		{
+			name: "velero restore found and status is completed, have config map so wait!",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				restoreName:      "creds-restore-name-4",
+				restoreNamespace: "default",
+				veleroRestore:    *createRestore("creds-restore-name-4", "default").phase("Completed").object,
+				pvMap: *createConfigMap("hub-pvc-backup-mongo-storage-4", "default", map[string]string{
+					"cluster.open-cluster-management.io/backup-pvc": "mongo-storage",
+				}),
+				pvc: *createPVC("mongo-storage-4", "default"), // this is NOT the expected PVC, not matching the map label !
+			},
+			want: true,
+		},
+		{
+			name: "velero restore found and status is completed, have config map but the PVC exists so NO wait!",
+			args: args{
+				ctx:              context.Background(),
+				c:                k8sClient1,
+				restoreName:      "creds-restore-name-5",
+				restoreNamespace: "default",
+				veleroRestore:    *createRestore("creds-restore-name-5", "default").phase("Completed").object,
+				pvMap: *createConfigMap("hub-pvc-backup-mongo-storage-5", "default", map[string]string{
+					"cluster.open-cluster-management.io/backup-pvc": "mongo-storage",
+				}),
+				pvc: *createPVC("mongo-storage", "default"), // this is the expected PVC, matching the map label !
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err := k8sClient1.Create(context.Background(), &tt.args.veleroRestore); err != nil {
+			t.Errorf("cannot create resource %v", err.Error())
+		}
+
+		if err := k8sClient1.Create(context.Background(), &tt.args.pvMap); err != nil {
+			t.Errorf("cannot create resource %v", err.Error())
+
+		}
+
+		if err := k8sClient1.Create(context.Background(), &tt.args.pvc); err != nil {
+			t.Errorf("cannot create resource %v", err.Error())
+
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			if shouldWait, msg := processRestoreWait(tt.args.ctx, tt.args.c,
+				tt.args.restoreName, tt.args.restoreNamespace); shouldWait != tt.want {
+				t.Errorf("processRestoreWait() returns = %v, want %v, msg=%v", shouldWait, tt.want, msg)
+			}
+		})
+	}
+	// clean up
+	testEnv.Stop()
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9717


If a configMap with 
cluster.open-cluster-management.io/backup-pvc label is found during a restore operation, the backup operator must wait for the PVC to be created ( by the pvc policy , which also restores the snapshot using a volsync DestinationReplication) , before creating activation resources. This allow the PVC to be restored before the app using the pvc uses the volume.
The issue reported here : The operator waits for the PVC but if, during the wait, another credentials backup is created by the primary hub , the new credential is picked up and because the wait stops.
The wait should not resume if only credential backups have been restored.

Version-Release number of selected component (if applicable):
How reproducible:
Always

Steps to Reproduce:

1. On the primary hub ( have the pv policy installed ) then set the  cluster.open-cluster-management.io/backup-hub-pvc label on a PVC so the configmap with  cluster.open-cluster-management.io/backup-pvc is created and backed up
2.  Run an acm backup schedule on the restore hub to make sure the data is backed up
3.  Go to the restore hub:

- On the restore hub remove the pvc policies so that after a restore you get into the wait stage
- Run a restore all operation
- You should see the Restore status saying : wait for PVC to be created.. ; and shows the. credentials file restored 
- Now go back on the backup hub and trigger a new backup ( delete one of the velero schedules , this should trigger that )

4. Go back to the restore hub and wait until the new backup is sync up and picked up by the restore op ( which uses latest as the option to restore )
5. You should see at some point in the acm restore status that the new credentials backup was restored ( you can also check that you see the velero restore resource )
6.  Notice the wait is resumed and all resources are restored, even though the PVC was not created yet
7. Notice the wait is resumed and all resources are restored, even though the PVC was not created yet 

Actual results:
Notice the wait is resumed and all resources are restored, even though the PVC was not created yet 

Expected results:
Step 7 should not happen; the restore should still say wait until the PVC is created, even if a second credentials backup was restored.