### PR TITLE
update backup resources based on server foundation request

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,17 +195,26 @@ With this approach the backup includes all CRDs installed on the hub, including 
 
 
 1. Exclude all resources in the MultiClusterHub namespace. This is to avoid backing up installation resources which are linked to the current Hub identity and should not be backed up.
-2. Backup all CRDs with an api version suffixed by `.open-cluster-management.io`. This will cover all Advanced Cluster Management resources.
-3. Additionally, backup all CRDs from these api groups: `argoproj.io`,`app.k8s.io`,`core.observatorium.io`,`hive.openshift.io`
-4. Exclude all CRDs from the following api groups : `admission.cluster.open-cluster-management.io`,
-  `admission.work.open-cluster-management.io`,
-  `internal.open-cluster-management.io`,
-  `operator.open-cluster-management.io`,
-  `work.open-cluster-management.io`,
-  `search.open-cluster-management.io`,
-  `admission.hive.openshift.io`,
-  `velero.io`
-5. Exclude the following CRDs; they are part of the included api groups but are either not needed or they are being recreated by owner resources, which are also backed up: `clustermanagementaddon`, `observabilityaddon`, `applicationmanager`,`certpolicycontroller`,`iampolicycontroller`,`policycontroller`,`searchcollector`,`workmanager`,`backupschedule`,`restore`,`clusterclaim.cluster.open-cluster-management.io`
+2. Backup all CRDs with an api version suffixed by `.open-cluster-management.io` and `.hive.openshift.io`. This will cover all Advanced Cluster Management resources.
+3. Additionally, backup all CRDs from these api groups: `argoproj.io`,`app.k8s.io`,`core.observatorium.io`,`hive.openshift.io` under the resources backup and all CRDs from this group `agent-install.openshift.io` under the managed-clusters backup.
+4. Exclude all CRDs from the following api groups : 
+		"internal.open-cluster-management.io",
+		"operator.open-cluster-management.io",
+		"work.open-cluster-management.io",
+		"search.open-cluster-management.io",
+		"admission.hive.openshift.io",
+		"proxy.open-cluster-management.io",
+		"action.open-cluster-management.io",
+		"view.open-cluster-management.io",
+		"clusterview.open-cluster-management.io",
+		"velero.io",
+5. Exclude the following CRDs; they are part of the included api groups but are either not needed or they are being recreated by owner resources, which are also backed up: 		
+    "clustermanagementaddon.addon.open-cluster-management.io",
+		"backupschedule.cluster.open-cluster-management.io",
+		"restore.cluster.open-cluster-management.io",
+		"clusterclaim.cluster.open-cluster-management.io",
+		"discoveredcluster.discovery.open-cluster-management.io",
+		"placementdecisions.cluster.open-cluster-management.io",
 6. Backup secrets and configmaps with one of the following labels:
 `cluster.open-cluster-management.io/type`, `hive.openshift.io/secret-type`, `cluster.open-cluster-management.io/backup`
 7. Use this label for any other resources that should be backed up and are not included in the above criteria: `cluster.open-cluster-management.io/backup`

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -74,13 +74,15 @@ var (
 	// we want those CRs to be labeled with cluster.open-cluster-management.io/backup
 	// so they are picked up by the resources-generic backup
 	excludedAPIGroups = []string{
-		"admission.cluster.open-cluster-management.io",
-		"admission.work.open-cluster-management.io",
 		"internal.open-cluster-management.io",
 		"operator.open-cluster-management.io",
 		"work.open-cluster-management.io",
 		"search.open-cluster-management.io",
 		"admission.hive.openshift.io",
+		"proxy.open-cluster-management.io",
+		"action.open-cluster-management.io",
+		"view.open-cluster-management.io",
+		"clusterview.open-cluster-management.io",
 		"velero.io",
 	}
 	// exclude these CRDs
@@ -88,17 +90,11 @@ var (
 	// or they are being recreated by owner resources, which are also backed up
 	excludedCRDs = []string{
 		"clustermanagementaddon.addon.open-cluster-management.io",
-		"observabilityaddon.observability.open-cluster-management.io",
-		"applicationmanager.agent.open-cluster-management.io",
-		"certpolicycontroller.agent.open-cluster-management.io",
-		"iampolicycontroller.agent.open-cluster-management.io",
-		"policycontroller.agent.open-cluster-management.io",
-		"searchcollector.agent.open-cluster-management.io",
-		"workmanager.agent.open-cluster-management.io",
 		"backupschedule.cluster.open-cluster-management.io",
 		"restore.cluster.open-cluster-management.io",
 		"clusterclaim.cluster.open-cluster-management.io",
 		"discoveredcluster.discovery.open-cluster-management.io",
+		"placementdecisions.cluster.open-cluster-management.io",
 	}
 
 	// resources used to activate the connection between hub and managed clusters - activation resources

--- a/controllers/backup_test.go
+++ b/controllers/backup_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Backup", func() {
 
 			Expect(shouldBackupAPIGroup("security.openshift.io")).Should(BeFalse())
 			Expect(
-				shouldBackupAPIGroup("admission.cluster.open-cluster-management.io"),
+				shouldBackupAPIGroup("proxy.open-cluster-management.io"),
 			).Should(BeFalse())
 			Expect(shouldBackupAPIGroup("discovery.open-cluster-management.io")).Should(BeTrue())
 			Expect(shouldBackupAPIGroup("argoproj.io")).Should(BeTrue())

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -1758,9 +1758,9 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 	bsSGVKList := schema.GroupVersionResource{Group: "cluster.open-cluster-management.io",
 		Version: "v1beta1", Resource: "backupschedules"}
 	//mutators
-	mGVK := schema.GroupVersionKind{Group: "admission.cluster.open-cluster-management.io",
+	mGVK := schema.GroupVersionKind{Group: "proxy.open-cluster-management.io",
 		Version: "v1beta1", Kind: "AdmissionReview"}
-	mVKList := schema.GroupVersionResource{Group: "admission.cluster.open-cluster-management.io",
+	mVKList := schema.GroupVersionResource{Group: "proxy.open-cluster-management.io",
 		Version: "v1beta1", Resource: "managedclustermutators"}
 	//pools
 	cpGVK := schema.GroupVersionKind{Group: "hive.openshift.io",
@@ -1910,7 +1910,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 		},
 	}
 	excluded := metav1.APIResourceList{
-		GroupVersion: "admission.cluster.open-cluster-management.io/v1beta1",
+		GroupVersion: "proxy.open-cluster-management.io/v1beta1",
 		APIResources: []metav1.APIResource{
 			{Name: "managedclustermutators", Namespaced: false, Kind: "AdmissionReview"},
 		},
@@ -1939,7 +1939,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 			list = &clusterv1beta1Info
 		case "/apis/cluster.open-cluster-management.io/v1":
 			list = &clusterv1Info
-		case "/apis/admission.cluster.open-cluster-management.io/v1beta1":
+		case "/apis/proxy.open-cluster-management.io/v1beta1":
 			list = &excluded
 		case "/apis/hive.openshift.io/v1":
 			list = &hiveInfo
@@ -2002,14 +2002,14 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 						},
 					},
 					{
-						Name: "admission.cluster.open-cluster-management.io",
+						Name: "proxy.open-cluster-management.io",
 						Versions: []metav1.GroupVersionForDiscovery{
 							{
-								GroupVersion: "admission.cluster.open-cluster-management.io/v1beta1",
+								GroupVersion: "proxy.open-cluster-management.io/v1beta1",
 								Version:      "v1beta1",
 							},
 							{
-								GroupVersion: "admission.cluster.open-cluster-management.io/v1",
+								GroupVersion: "proxy.open-cluster-management.io/v1",
 								Version:      "v1",
 							},
 						},

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -885,7 +885,7 @@ var _ = Describe("BackupSchedule controller", func() {
 						"clusterdeployment.hive.openshift.io")).Should(BeFalse())
 					Expect(findValue(
 						veleroSchedule.Spec.Template.IncludedResources, //excludedGroup
-						"managedclustermutators.admission.cluster.open-cluster-management.io",
+						"managedclustermutators.proxy.open-cluster-management.io",
 					)).ShouldNot(BeTrue())
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
 						"clusterpool.other.hive.openshift.io")).Should(BeFalse())

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -262,7 +262,6 @@ func Test_getSchedulesWithUpdatedResources(t *testing.T) {
 	}
 
 	resourcesToBackup := []string{
-		"managedproxyserviceresolver.proxy.open-cluster-management.io",
 		"channel.apps.open-cluster-management.io",
 		"iampolicy.policy.open-cluster-management.io",
 		"agentclusterinstall.extensions.hive.openshift.io",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -143,7 +143,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	excluded := metav1.APIResourceList{
-		GroupVersion: "admission.cluster.open-cluster-management.io/v1beta1",
+		GroupVersion: "proxy.open-cluster-management.io/v1beta1",
 		APIResources: []metav1.APIResource{
 			{Name: "managedclustermutators", Namespaced: false, Kind: "AdmissionReview"},
 		},
@@ -176,7 +176,7 @@ var _ = BeforeSuite(func() {
 			list = &clusterv1beta1Info
 		case "/apis/cluster.open-cluster-management.io/v1":
 			list = &clusterv1Info
-		case "/apis/admission.cluster.open-cluster-management.io/v1beta1":
+		case "/apis/proxy.open-cluster-management.io/v1beta1":
 			list = &excluded
 		case "/apis/hive.openshift.io/v1":
 			list = &hiveInfo
@@ -243,14 +243,14 @@ var _ = BeforeSuite(func() {
 						},
 					},
 					{
-						Name: "admission.cluster.open-cluster-management.io",
+						Name: "proxy.open-cluster-management.io",
 						Versions: []metav1.GroupVersionForDiscovery{
 							{
-								GroupVersion: "admission.cluster.open-cluster-management.io/v1beta1",
+								GroupVersion: "proxy.open-cluster-management.io/v1beta1",
 								Version:      "v1beta1",
 							},
 							{
-								GroupVersion: "admission.cluster.open-cluster-management.io/v1",
+								GroupVersion: "proxy.open-cluster-management.io/v1",
 								Version:      "v1",
 							},
 						},
@@ -358,8 +358,8 @@ var _ = BeforeSuite(func() {
 		},
 		{
 			resourcesList: &excluded,
-			path:          "/apis/admission.cluster.open-cluster-management.io/v1beta1",
-			request:       "admission.cluster.open-cluster-management.io/v1beta1",
+			path:          "/apis/proxy.open-cluster-management.io/v1beta1",
+			request:       "proxy.open-cluster-management.io/v1beta1",
 			expectErr:     false,
 		},
 	}
@@ -591,9 +591,9 @@ var _ = BeforeSuite(func() {
 	bsSGVKList := schema.GroupVersionResource{Group: "cluster.open-cluster-management.io",
 		Version: "v1beta1", Resource: "backupschedules"}
 	//mutators
-	mGVK := schema.GroupVersionKind{Group: "admission.cluster.open-cluster-management.io",
+	mGVK := schema.GroupVersionKind{Group: "proxy.open-cluster-management.io",
 		Version: "v1beta1", Kind: "AdmissionReview"}
-	mVKList := schema.GroupVersionResource{Group: "admission.cluster.open-cluster-management.io",
+	mVKList := schema.GroupVersionResource{Group: "proxy.open-cluster-management.io",
 		Version: "v1beta1", Resource: "managedclustermutators"}
 	//pools
 	cpGVK := schema.GroupVersionKind{Group: "other.hive.openshift.io",


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9732

Changes as requested by the server foundation team

Exclude resources with the following API group suffix:
proxy.open-cluster-management.io
action.open-cluster-management.io
view.open-cluster-management.io
clusterview.open-cluster-management.io
Exclude the particular resources below:
placementdecisions.cluster.open-cluster-management.io
The following API group suffix or resources no longer exist in ACM 2.10, it's safe to remove them from both the code and the doc.
admission.cluster.open-cluster-management.io
admission.work.open-cluster-management.io
observabilityaddon
applicationmanager
certpolicycontroller
iampolicycontroller
policycontroller
searchcollector
workmanager