### PR TITLE
add back placementdecisions.cluster.open-cluster-management.io

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -94,7 +94,6 @@ var (
 		"restore.cluster.open-cluster-management.io",
 		"clusterclaim.cluster.open-cluster-management.io",
 		"discoveredcluster.discovery.open-cluster-management.io",
-		"placementdecisions.cluster.open-cluster-management.io",
 	}
 
 	// resources used to activate the connection between hub and managed clusters - activation resources


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9732

server foundation team wants to keep the placementdecisions.cluster.open-cluster-management.io in the backup until a decision is made whether this is used