### PR TITLE
restore msa ManifestWork at cluster activation

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -585,7 +585,7 @@ func createManifestWork(
 				manifestWork.Namespace = namespace
 				manifestWork.Labels = map[string]string{
 					addon_work_label:        msa_addon,
-					backupCredsClusterLabel: "msa"}
+					backupCredsClusterLabel: ClusterActivationLabel}
 
 				manifest := &workv1.Manifest{}
 				manifest.Raw = []byte(fmt.Sprintf(manifestwork, mworkBinding, role_name, msaserviceName, installNamespace))


### PR DESCRIPTION
related to https://issues.redhat.com/browse/ACM-9780

Any backed up ManifestWork should be restored at activation time, after managed cluster CRs