### PR TITLE
filter out MSA tokens not used by auto-import

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -626,7 +626,7 @@ func getMSASecrets(
 			if err := c.List(ctx, msaSecrets, &client.ListOptions{
 				LabelSelector: selector,
 			}); err == nil {
-				return msaSecrets.Items
+				return retrieveMSAImportSecrets(msaSecrets.Items)
 			}
 		} else {
 			// get secrets from specified namespace
@@ -634,12 +634,28 @@ func getMSASecrets(
 				Namespace:     namespace,
 				LabelSelector: selector,
 			}); err == nil {
-				return msaSecrets.Items
+				return retrieveMSAImportSecrets(msaSecrets.Items)
 			}
 		}
 
 	}
 	return []corev1.Secret{}
+}
+
+// return only secrets with a prefix of msa_service_name
+func retrieveMSAImportSecrets(
+	secrets []corev1.Secret,
+) []corev1.Secret {
+
+	msaSecrets := []corev1.Secret{}
+
+	for i := range secrets {
+		if strings.HasPrefix(secrets[i].Name, msa_service_name) {
+			msaSecrets = append(msaSecrets, secrets[i])
+		}
+	}
+
+	return msaSecrets
 }
 
 // prepare managed service account secrets for backup

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -105,12 +105,12 @@ func Test_postRestoreActivation(t *testing.T) {
 				},
 
 				secrets: []corev1.Secret{
-					*createSecret("auto-import", "local-cluster",
+					*createSecret("auto-import-account", "local-cluster",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
 						}, nil),
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
@@ -136,19 +136,19 @@ func Test_postRestoreActivation(t *testing.T) {
 						}).object,
 				},
 				secrets: []corev1.Secret{
-					*createSecret("auto-import", "local-cluster",
+					*createSecret("auto-import-account", "local-cluster",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
 						}, nil),
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
 						}, map[string][]byte{
 							"token": []byte("YWRtaW4="),
 						}),
-					*createSecret("auto-import", "managed2",
+					*createSecret("auto-import-account", "managed2",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
@@ -194,19 +194,19 @@ func Test_postRestoreActivation(t *testing.T) {
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 						}, nil),
-					*createSecret("auto-import", "local-cluster",
+					*createSecret("auto-import-account", "local-cluster",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
 						}, nil),
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
 						}, map[string][]byte{
 							"token": []byte("YWRtaW4="),
 						}),
-					*createSecret("auto-import", "managed2",
+					*createSecret("auto-import-account", "managed2",
 						nil, map[string]string{
 							"lastRefreshTimestamp": fourHoursAgo,
 							"expirationTimestamp":  nextTenHours,
@@ -1611,7 +1611,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 		"apiVersion": "authentication.open-cluster-management.io/v1beta1",
 		"kind":       "ManagedServiceAccount",
 		"metadata": map[string]interface{}{
-			"name":      "auto-import",
+			"name":      "auto-import-account",
 			"namespace": "managed1",
 			"labels": map[string]interface{}{
 				msa_label: msa_service_name,

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -120,7 +120,21 @@ var _ = Describe("BackupSchedule controller", func() {
 		clusterPoolSecrets = []corev1.Secret{
 			*createSecret("app-prow-47-aws-creds", clusterPoolNSName,
 				nil, nil, nil),
-			*createSecret("auto-import", clusterPoolNSName,
+			*createSecret("auto-import-account", clusterPoolNSName,
+				map[string]string{
+					"authentication.open-cluster-management.io/is-managed-serviceaccount": "true",
+				}, map[string]string{
+					"expirationTimestamp":  "2024-08-05T15:25:34Z",
+					"lastRefreshTimestamp": "2022-07-26T15:25:34Z",
+				}, nil),
+			*createSecret("auto-import-account-pair", clusterPoolNSName,
+				map[string]string{
+					"authentication.open-cluster-management.io/is-managed-serviceaccount": "true",
+				}, map[string]string{
+					"expirationTimestamp":  "2024-08-05T15:25:34Z",
+					"lastRefreshTimestamp": "2022-07-26T15:25:34Z",
+				}, nil),
+			*createSecret("some-other-msa-account", clusterPoolNSName,
 				map[string]string{
 					"authentication.open-cluster-management.io/is-managed-serviceaccount": "true",
 				}, map[string]string{
@@ -296,7 +310,7 @@ var _ = Describe("BackupSchedule controller", func() {
 		if clusterPoolNS != nil {
 
 			for i := range clusterPoolSecrets {
-				if clusterPoolSecrets[i].Name == "auto-import" {
+				if clusterPoolSecrets[i].Name == "auto-import-account" || clusterPoolSecrets[i].Name == "auto-import-account-pair" {
 					// this should be already cleaned up by the MSA disabled function
 					Expect(k8sClient.Delete(ctx, &clusterPoolSecrets[i])).ShouldNot(Succeed())
 				} else {
@@ -484,12 +498,32 @@ var _ = Describe("BackupSchedule controller", func() {
 			autoImportSecret := corev1.Secret{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "auto-import",
+					Name:      "auto-import-account",
 					Namespace: clusterPoolNSName,
 				}, &autoImportSecret)
 				return err == nil &&
 					autoImportSecret.GetLabels()["cluster.open-cluster-management.io/backup"] == "msa"
 			}, timeout, interval).Should(Equal(rhacmBackupSchedule.Spec.UseManagedServiceAccount))
+
+			// verify pair secret gets backup label
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "auto-import-account-pair",
+					Namespace: clusterPoolNSName,
+				}, &autoImportSecret)
+				return err == nil &&
+					autoImportSecret.GetLabels()["cluster.open-cluster-management.io/backup"] == "msa"
+			}, timeout, interval).Should(Equal(rhacmBackupSchedule.Spec.UseManagedServiceAccount))
+
+			// verify other typo of msa secret DOES NOT get the backup label
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "some-other-msa-account",
+					Namespace: clusterPoolNSName,
+				}, &autoImportSecret)
+				return err == nil &&
+					autoImportSecret.GetLabels()["cluster.open-cluster-management.io/backup"] == "msa"
+			}, timeout, interval).ShouldNot(Equal(rhacmBackupSchedule.Spec.UseManagedServiceAccount))
 
 			// validate that the managedserviceaccount ManagedClusterAddOn is created for managed clusters since
 			// useManagedServiceAccount is true

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -515,7 +515,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					autoImportSecret.GetLabels()["cluster.open-cluster-management.io/backup"] == "msa"
 			}, timeout, interval).Should(Equal(rhacmBackupSchedule.Spec.UseManagedServiceAccount))
 
-			// verify other typo of msa secret DOES NOT get the backup label
+			// verify other type of msa secret DOES NOT get the backup label
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      "some-other-msa-account",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -478,7 +478,7 @@ var _ = BeforeSuite(func() {
 		"apiVersion": "authentication.open-cluster-management.io/v1beta1",
 		"kind":       "ManagedServiceAccount",
 		"metadata": map[string]interface{}{
-			"name":      "auto-import",
+			"name":      "auto-import-account",
 			"namespace": "managed1",
 			"labels": map[string]interface{}{
 				msa_label: msa_service_name,
@@ -499,7 +499,7 @@ var _ = BeforeSuite(func() {
 		"apiVersion": "authentication.open-cluster-management.io/v1beta1",
 		"kind":       "ManagedServiceAccount",
 		"metadata": map[string]interface{}{
-			"name":      "auto-import",
+			"name":      "auto-import-account",
 			"namespace": "app",
 			"labels": map[string]interface{}{
 				msa_label: msa_service_name,

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -343,7 +343,7 @@ func Test_findValidMSAToken(t *testing.T) {
 			args: args{
 				currentTime: current,
 				secrets: []corev1.Secret{
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"expirationTimestamp": fourHoursAgo,
 						}, nil),
@@ -355,7 +355,7 @@ func Test_findValidMSAToken(t *testing.T) {
 			args: args{
 				currentTime: current,
 				secrets: []corev1.Secret{
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"expirationTimestamp": nextHour,
 						}, map[string][]byte{
@@ -369,13 +369,13 @@ func Test_findValidMSAToken(t *testing.T) {
 			args: args{
 				currentTime: current,
 				secrets: []corev1.Secret{
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"expirationTimestamp": nextHour,
 						}, map[string][]byte{
 							"token1": []byte("aaa"),
 						}),
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"expirationTimestamp": nextHour,
 						}, map[string][]byte{
@@ -389,7 +389,7 @@ func Test_findValidMSAToken(t *testing.T) {
 			args: args{
 				currentTime: current,
 				secrets: []corev1.Secret{
-					*createSecret("auto-import", "managed1",
+					*createSecret("auto-import-account", "managed1",
 						nil, map[string]string{
 							"expirationTimestamp": nextHour,
 						}, map[string][]byte{


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10093

Issue: When restoring managed clusters data and auto-import-account MSA are used to connect to the clusters, the list of MSA used by the restore operation should only include tokens created by an MSA with the auto-import-account name
If not, other MSA secrets can be picked up to be used by the auto-import-secret and those tokens don't have authority to run the import operation

Fix:
When looking for MSA tokens filter out and get only the ones with a name prefix `auto-import-account` 

