### PR TITLE
Ubi9 and konflux dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,0 +1,27 @@
+# Build the manager binary
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 AS builder
+
+WORKDIR /workspace
+# Copy the source files
+COPY main.go main.go
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY api/. api/
+COPY config/. config/
+COPY controllers/ controllers/
+
+# Copy the go source
+RUN  CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go mod vendor
+RUN  CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go mod tidy
+
+# Build
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Update upstream dockerfile to use ubi9 and also checkin Dockerfile.rhtap for konflux.

Committing to main and will ffwd to release-2.11