### PR TITLE
dependent crd checks at startup

### DIFF
--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -615,3 +615,58 @@ func Test_getHubIdentification(t *testing.T) {
 	testEnv.Stop()
 
 }
+
+func Test_VeleroCRDsPresent_NotPresent(t *testing.T) {
+	// Test env with no additional CRDs (velero crds will not be present)
+	testEnv := &envtest.Environment{ErrorIfCRDPathMissing: true}
+	cfg, _ := testEnv.Start()
+
+	// clean up after
+	defer testEnv.Stop()
+
+	scheme1 := runtime.NewScheme()
+	_ = veleroapi.AddToScheme(scheme1) // for velero types
+
+	// test client to testEnv above with no velero CRDs
+	k8sClient1, _ := client.New(cfg, client.Options{Scheme: scheme1})
+
+	t.Run("velero CRDs not present", func(t *testing.T) {
+		crdsPresent, err := VeleroCRDsPresent(context.Background(), k8sClient1)
+		if err != nil {
+			t.Errorf("VeleroCRDsPresent() returned an unexpected error %s", err.Error())
+		}
+		if crdsPresent {
+			t.Errorf("VeleroCRDsPresent() should return false when CRDs not present")
+		}
+	})
+}
+
+func Test_VeleroCRDsPresent(t *testing.T) {
+	// Test env with our dependent CRDs loaded
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, _ := testEnv.Start()
+
+	// clean up after
+	defer testEnv.Stop()
+
+	scheme1 := runtime.NewScheme()
+	_ = veleroapi.AddToScheme(scheme1) // for velero types
+
+	// test client to testEnv above with no velero CRDs
+	k8sClient1, _ := client.New(cfg, client.Options{Scheme: scheme1})
+
+	// Rely on testEnv setup in suite_test.go (this will have all the CRDs)
+	// (use k8sClient setup in BeforeSuite that talks to the testEnv)
+	t.Run("velero CRDs present", func(t *testing.T) {
+		crdsPresent, err := VeleroCRDsPresent(context.Background(), k8sClient1)
+		if err != nil {
+			t.Errorf("VeleroCRDsPresent() returned an unexpected error %s", err.Error())
+		}
+		if !crdsPresent {
+			t.Errorf("VeleroCRDsPresent() should return true when CRDs are present")
+		}
+	})
+}


### PR DESCRIPTION
If Velero CRDs are missing, starting controllers will crash as they have a watch on velero Schedule and Restore resources.  Adding a check that only happens prior to controller startup so we can wait for the CRDs to appear.

In a loop, checking every 30s at startup (before starting manager & controllers):
- Check for Velero Schedule and Restore CRDs at startup
- If either are not present, do not start controllers