### PR TITLE
generate a dummy backup when managed clusters are restored on a hub ( https://issues.redhat.com/browse/ACM-11860 )

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -678,7 +678,7 @@ func processRetrieveRestoreDetails(
 			}
 
 			veleroRestore := &veleroapi.Restore{}
-			veleroBackupName, _, err := getVeleroBackupName(
+			veleroBackupName, veleroBackup, err := getVeleroBackupName(
 				ctx,
 				c,
 				acmRestore.Namespace,
@@ -711,6 +711,14 @@ func processRetrieveRestoreDetails(
 
 				veleroRestore.Namespace = acmRestore.Namespace
 				veleroRestore.Spec.BackupName = veleroBackupName
+
+				// set backup label
+				labels := veleroRestore.GetLabels()
+				if labels == nil {
+					labels = make(map[string]string)
+				}
+				labels[BackupScheduleClusterLabel] = veleroBackup.GetLabels()[BackupScheduleClusterLabel]
+				veleroRestore.SetLabels(labels)
 
 				setOptionalProperties(key, acmRestore, veleroRestore)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-11860

Create a dummy backup when a restore of managed clusters are being executed on the passive hub. 
This backup has label annotations for
- clusterID where the restore was completed
- clusterID where the backup was created
- backup name used to run the restore operation
- the backup TTL is set to use the default velero TTL 

This backup can be seen by all hubs connected to the same storage location so the information that a restore of managed clusters has been executed is available to all hubs

Sample 

```
apiVersion: velero.io/v1
kind: Backup
metadata:
  name: acm-restore-clusters-20240523120542
  uid: 98ae0b26-d0ab-4f42-8e74-f9c4e429e1a3
  creationTimestamp: '2024-05-23T16:06:22Z'
  namespace: open-cluster-management-backup
  labels:
    acm-managed-clusters-schedule: acm-managed-clusters-schedule-20240523160022
    cluster.open-cluster-management.io/acm-hub-dr: 'true'
    cluster.open-cluster-management.io/acm-restore-name: restore-acm-passive-sync
    cluster.open-cluster-management.io/backup-cluster: 56670e8b-d843-4b24-a035-53c6d21552c6
    cluster.open-cluster-management.io/restore-cluster: 8ab0322c-ae47-4e8b-acb6-052d435ac8b8
    velero.io/storage-location: dpa-hub-b-1
spec:
  volumeSnapshotLocations:
    - dpa-hub-b-1
  defaultVolumesToFsBackup: false
  csiSnapshotTimeout: 10m0s
  includedResources:
    - Restore
  ttl: 720h0m0s
  itemOperationTimeout: 4h0m0s
  metadata: {}
  storageLocation: dpa-hub-b-1
  hooks: {}
  includedNamespaces:
    - open-cluster-management-backup
  snapshotMoveData: false
status:
  completionTimestamp: '2024-05-23T16:05:44Z'
  expiration: '2024-06-22T16:05:42Z'
  formatVersion: 1.1.0
  phase: Completed
  progress:
    itemsBackedUp: 1
    totalItems: 1
  startTimestamp: '2024-05-23T16:05:42Z'
  version: 1
```