### PR TITLE
show backup collision if restore activation run on another hub

### DIFF
--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -48,11 +48,11 @@ const (
 		" This is a backup collision with current cluster [%s] backup." +
 		" Review and resolve the collision then create a new BackupSchedule resource to " +
 		" resume backups from this cluster."
-	// BackupCollisionPhaseMsg when another cluster had run the restore managed cluster operation while this cluster schedule is active
-	BackupCollisionRestorePhaseMsg string = "Cluster with id [%s] had run a restore managed cluster operation, recorded by [%s]." +
-		" Current cluster is no longer the active cluster so the BackupSchedule is set to backup collision." +
-		" Review and resolve the collision then create a new BackupSchedule resource to " +
-		" resume backups from this cluster, or create a BackupSchedule on the [%s] cluster."
+	// Collision when another hub had run the restore managed cluster operation while this cluster schedule is active
+	BackupCollisionRestoreMsg string = "Hub with id [%s] had run a restore managed cluster operation, see [%s]." +
+		" Current hub is no longer the active cluster so the BackupSchedule is set to backup collision." +
+		" Review and resolve the collision then create a new BackupSchedule resource " +
+		" from this hub, or from the [%s] hub."
 )
 
 func updateScheduleStatus(
@@ -585,7 +585,7 @@ func isRestoreHubAfterSchedule(
 		restoreHubId := latestRestoreBackup.GetLabels()[RestoreClusterLabel]
 		if hubId, _ := getHubIdentification(ctx, c); hubId != restoreHubId {
 			// this backup schedule was create before the latest restore operation
-			msg := fmt.Sprintf(BackupCollisionRestorePhaseMsg,
+			msg := fmt.Sprintf(BackupCollisionRestoreMsg,
 				restoreHubId,
 				latestRestoreBackup.Name,
 				restoreHubId,

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -48,6 +48,11 @@ const (
 		" This is a backup collision with current cluster [%s] backup." +
 		" Review and resolve the collision then create a new BackupSchedule resource to " +
 		" resume backups from this cluster."
+	// BackupCollisionPhaseMsg when another cluster had run the restore managed cluster operation while this cluster schedule is active
+	BackupCollisionRestorePhaseMsg string = "Cluster with id [%s] had run a restore managed cluster operation, recorded by [%s]." +
+		" Current cluster is no longer the active cluster so the BackupSchedule is set to backup collision." +
+		" Review and resolve the collision then create a new BackupSchedule resource to " +
+		" resume backups from this cluster, or create a BackupSchedule on the [%s] cluster."
 )
 
 func updateScheduleStatus(
@@ -547,4 +552,48 @@ func isVeleroSchedulesUpdateRequired(
 	}
 
 	return ctrl.Result{}, false, nil
+}
+
+// returns true if there was a passive activation after this schedule was created
+// this means that another hub has been designated the active hub and this schedule should no longer execute
+func isRestoreHubAfterSchedule(
+	ctx context.Context,
+	c client.Client,
+	backupSchedule *v1beta1.BackupSchedule,
+) (bool, string) {
+
+	logger := log.FromContext(ctx)
+
+	// get all acm-restore-clusters backups and sort them by creation timestamp
+	restoreClustersBackups := &veleroapi.BackupList{}
+	if err := c.List(ctx, restoreClustersBackups, client.InNamespace(backupSchedule.Namespace),
+		client.HasLabels{RestoreClusterLabel}); err != nil {
+		logger.Error(
+			err,
+			"Failed to get new Velero restore backups",
+		)
+		return false, ""
+	}
+	if len(restoreClustersBackups.Items) == 0 {
+		// no managed clusters restore backups found
+		return false, ""
+	}
+
+	sort.Sort(mostRecent(restoreClustersBackups.Items))
+	latestRestoreBackup := restoreClustersBackups.Items[0]
+	if backupSchedule.CreationTimestamp.Time.Before(latestRestoreBackup.CreationTimestamp.Time) {
+		restoreHubId := latestRestoreBackup.GetLabels()[RestoreClusterLabel]
+		if hubId, _ := getHubIdentification(ctx, c); hubId != restoreHubId {
+			// this backup schedule was create before the latest restore operation
+			msg := fmt.Sprintf(BackupCollisionRestorePhaseMsg,
+				restoreHubId,
+				latestRestoreBackup.Name,
+				restoreHubId,
+			)
+			logger.Info(msg)
+			return true, msg
+		}
+	}
+
+	return false, ""
 }

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	ocinfrav1 "github.com/openshift/api/config/v1"
 	"github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	backupv1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -1242,6 +1243,163 @@ func Test_scheduleOwnsLatestStorageBackups(t *testing.T) {
 
 	}
 	// clean up
+	testEnv.Stop()
+
+}
+
+func Test_isRestoreHubAfterSchedule(t *testing.T) {
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join("..", "hack", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, _ := testEnv.Start()
+	scheme2 := runtime.NewScheme()
+	corev1.AddToScheme(scheme2)
+	backupv1beta1.AddToScheme(scheme2)
+	ocinfrav1.AddToScheme(scheme2)
+
+	k8sClient1, _ := client.New(cfg, client.Options{Scheme: scheme2})
+
+	veleroNamespaceName := "backup-ns"
+	veleroNamespace := *createNamespace(veleroNamespaceName)
+	k8sClient1.Create(context.Background(), &veleroNamespace)
+
+	crWithVersion := createClusterVersion("version", "cluster1", nil)
+	if err := k8sClient1.Create(context.Background(), crWithVersion); err != nil {
+		t.Errorf("cannot create cluster version  %s ", err.Error())
+	}
+
+	type args struct {
+		ctx                         context.Context
+		c                           client.Client
+		backupSchedule              *v1beta1.BackupSchedule
+		acmClusterActivationBackups []*veleroapi.Backup
+		createScheduleFirst         bool
+		sleepTime                   int
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "no collision, list backup fails",
+			args: args{
+				ctx: context.Background(),
+				c:   k8sClient1,
+				backupSchedule: createBackupSchedule("acm-backup-schedule", veleroNamespaceName).
+					object,
+				acmClusterActivationBackups: []*veleroapi.Backup{},
+				createScheduleFirst:         true,
+				sleepTime:                   2,
+			},
+			want: false,
+		},
+		{
+			name: "no collision, no backup restore found",
+			args: args{
+				ctx: context.Background(),
+				c:   k8sClient1,
+				backupSchedule: createBackupSchedule("acm-backup-schedule", veleroNamespaceName).
+					object,
+				acmClusterActivationBackups: []*veleroapi.Backup{},
+				createScheduleFirst:         true,
+				sleepTime:                   2,
+			},
+			want: false,
+		},
+		{
+			name: "collision, backup schedule created first, before restore",
+			args: args{
+				ctx: context.Background(),
+				c:   k8sClient1,
+				backupSchedule: createBackupSchedule("acm-backup-schedule", veleroNamespaceName).
+					object,
+				acmClusterActivationBackups: []*veleroapi.Backup{createBackup("acm-restore-clusters-2", veleroNamespaceName).
+					labels(map[string]string{BackupScheduleClusterLabel: "cluster1",
+						RestoreClusterLabel: "cluster2"}).
+					phase(veleroapi.BackupPhaseCompleted).
+					object},
+				createScheduleFirst: true,
+				sleepTime:           2,
+			},
+			want: true,
+		},
+		{
+			name: "no collision, backup schedule created first, before restore,  but on the same hub",
+			args: args{
+				ctx: context.Background(),
+				c:   k8sClient1,
+				backupSchedule: createBackupSchedule("acm-backup-schedule", veleroNamespaceName).
+					object,
+				acmClusterActivationBackups: []*veleroapi.Backup{createBackup("acm-restore-clusters-1", veleroNamespaceName).
+					labels(map[string]string{BackupScheduleClusterLabel: "cluster1",
+						RestoreClusterLabel: "cluster1"}).
+					phase(veleroapi.BackupPhaseCompleted).
+					object},
+				createScheduleFirst: true,
+				sleepTime:           2,
+			},
+			want: false,
+		},
+		{
+			name: "no collision, backup schedule created after restore",
+			args: args{
+				ctx: context.Background(),
+				c:   k8sClient1,
+				backupSchedule: createBackupSchedule("acm-backup-schedule", veleroNamespaceName).
+					object,
+				acmClusterActivationBackups: []*veleroapi.Backup{createBackup("acm-restore-clusters-2", veleroNamespaceName).
+					labels(map[string]string{BackupScheduleClusterLabel: "cluster1",
+						RestoreClusterLabel: "cluster2"}).
+					phase(veleroapi.BackupPhaseCompleted).
+					object},
+				createScheduleFirst: false,
+				sleepTime:           2,
+			},
+			want: false,
+		},
+	}
+
+	for idx, tt := range tests {
+
+		if idx > 0 {
+			veleroapi.AddToScheme(scheme2)
+		}
+
+		if tt.args.createScheduleFirst {
+			k8sClient1.Create(tt.args.ctx, tt.args.backupSchedule)
+			time.Sleep(time.Duration(tt.args.sleepTime) * time.Second)
+			for i := range tt.args.acmClusterActivationBackups {
+				k8sClient1.Create(tt.args.ctx, tt.args.acmClusterActivationBackups[i])
+			}
+
+		} else {
+			for i := range tt.args.acmClusterActivationBackups {
+				k8sClient1.Create(tt.args.ctx, tt.args.acmClusterActivationBackups[i])
+			}
+			time.Sleep(time.Duration(tt.args.sleepTime) * time.Second)
+			k8sClient1.Create(tt.args.ctx, tt.args.backupSchedule)
+
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := isRestoreHubAfterSchedule(tt.args.ctx, tt.args.c,
+				tt.args.backupSchedule); got != tt.want {
+				t.Errorf("isRestoreHubAfterSchedule() = %v, want %v ", got, tt.want)
+			}
+		})
+
+		// clean up after the test is run
+		k8sClient1.Delete(tt.args.ctx, tt.args.backupSchedule)
+		for i := range tt.args.acmClusterActivationBackups {
+			k8sClient1.Delete(tt.args.ctx, tt.args.acmClusterActivationBackups[i])
+		}
+	}
 	testEnv.Stop()
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-11876

related to https://github.com/stolostron/cluster-backup-operator/pull/537

Scenario:

- hubA is active, backup schedules running
- hubB is passive
- hubA goes down unexpectedly 
- admin restores managed clusters on hubB and hubB becomes active hub
- hubA starts up; the backup schedule is still enabled
- since hubB is now the active hub, hubA schedule should be disabled

Changes : 
If a BackupSchedule runs on this hub, on reconcile, check if any acm-restore-clusters backup resource was created after the BackupSchedule was created. 
If a acm-restore-clusters backup resource was found, created after the BackupSchedule was created, and created by a different hub, set the BackupSchedule to BackupCollision and remove velero schedules
