### PR TITLE
Revert "[release-2.10] generate a dummy backup when managed clusters are restored on a hub ( https://issues.redhat.com/browse/ACM-11860 )"

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -678,7 +678,7 @@ func processRetrieveRestoreDetails(
 			}
 
 			veleroRestore := &veleroapi.Restore{}
-			veleroBackupName, veleroBackup, err := getVeleroBackupName(
+			veleroBackupName, _, err := getVeleroBackupName(
 				ctx,
 				c,
 				acmRestore.Namespace,
@@ -711,14 +711,6 @@ func processRetrieveRestoreDetails(
 
 				veleroRestore.Namespace = acmRestore.Namespace
 				veleroRestore.Spec.BackupName = veleroBackupName
-
-				// set backup label
-				labels := veleroRestore.GetLabels()
-				if labels == nil {
-					labels = make(map[string]string)
-				}
-				labels[BackupScheduleClusterLabel] = veleroBackup.GetLabels()[BackupScheduleClusterLabel]
-				veleroRestore.SetLabels(labels)
 
 				setOptionalProperties(key, acmRestore, veleroRestore)
 

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -42,10 +42,6 @@ const (
 	obs_addon_ns = "open-cluster-management-addon-observability"
 	/* #nosec G101 -- This is a false positive */
 	obs_secret_name = "observability-controller-open-cluster-management.io-observability-signer-client-cert"
-
-	// RestoreClusterLabel is the label key used to identify the cluster id
-	// that had run a restore clusters operation, so it had become the active hub
-	RestoreClusterLabel string = "cluster.open-cluster-management.io/restore-cluster"
 )
 
 // execute any tasks after restore is done
@@ -63,9 +59,7 @@ func executePostRestoreTasks(
 
 		// workaround for ACM-8406
 		deleteObsClientCert(ctx, c)
-		// broadcast the restore managed clusters operation by creating a backup resource
-		recordClustersRestoreOperation(ctx, c, acmRestore)
-
+		// get all managed clusters and run the auto import for imported clusters
 		managedClusters := &clusterv1.ManagedClusterList{}
 		if err := c.List(ctx, managedClusters, &client.ListOptions{}); err == nil {
 			processed = true
@@ -95,75 +89,6 @@ func deleteObsClientCert(
 			logger.Info("Secret deleted " + secret.Name)
 		}
 	}
-}
-
-// record the restore managed clusters operation by creating a backup resource
-// this is a dummy backup, its only purpose being to share with all hubs using
-// the current backup storage location
-// that a restore of managed clusters has been completed on this hub
-func recordClustersRestoreOperation(
-	ctx context.Context,
-	c client.Client,
-	acmRestore *v1beta1.Restore,
-) {
-
-	logger := log.FromContext(ctx)
-
-	currentTime := time.Now().Format("20060102150405")
-
-	veleroBackup := &veleroapi.Backup{}
-	veleroBackup.Name = "acm-restore-clusters-" + currentTime
-
-	logger.Info("recordClustersRestoreOperation " + veleroBackup.Name)
-
-	veleroBackup.Namespace = acmRestore.Namespace
-	// add restore details
-	labels := veleroBackup.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	managedClustersRestore := acmRestore.Status.VeleroManagedClustersRestoreName
-	veleroClsRestore := &veleroapi.Restore{}
-	if err := c.Get(ctx, types.NamespacedName{
-		Name:      managedClustersRestore,
-		Namespace: acmRestore.Namespace,
-	}, veleroClsRestore); err == nil {
-		logger.Info("Get backup hub cluster id")
-		labels[BackupScheduleClusterLabel] = veleroClsRestore.GetLabels()[BackupScheduleClusterLabel]
-	}
-
-	//set labels
-	labels["cluster.open-cluster-management.io/acm-hub-dr"] = "true"
-	labels["cluster.open-cluster-management.io/acm-restore-name"] = acmRestore.Name
-	labels[veleroBackupNames[ManagedClusters]] = veleroClsRestore.Spec.BackupName
-	// get this restore cluster id
-	clusterID, _ := getHubIdentification(ctx, c)
-	labels[RestoreClusterLabel] = clusterID
-	// set all labels
-	veleroBackup.SetLabels(labels)
-
-	// set spec from schedule spec
-	veleroBackup.Spec.IncludedNamespaces = appendUnique(
-		veleroBackup.Spec.IncludedNamespaces,
-		acmRestore.Namespace,
-	)
-	veleroBackup.Spec.IncludedResources = appendUnique(
-		veleroBackup.Spec.IncludedResources,
-		acmRestore.Kind,
-	)
-
-	// now create the backup, with a default ttl
-	if err := c.Create(ctx, veleroBackup, &client.CreateOptions{}); err != nil {
-		logger.Error(
-			err,
-			"Error in creating velero.io.Backup",
-			"name", veleroBackup.Name,
-			"namespace", veleroBackup.Namespace,
-		)
-	}
-
-	logger.Info("exit recordClustersRestoreOperation ")
 }
 
 // clean up resources with a restore label


### PR DESCRIPTION
Reverts stolostron/cluster-backup-operator#539

Decided this will not be backported to release-2.10