### PR TITLE
allow excluded CRDs to be backed up using backup label (https://issues.redhat.com/browse/ACM-12221)

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -376,12 +376,7 @@ func getResourcesByBackupType(
 			}
 		}
 	case ResourcesGeneric:
-		for i := range excludedCRDs { // exclude resources not backed up
-			filteredResourceNames = appendUnique(
-				filteredResourceNames,
-				excludedCRDs[i],
-			)
-		}
+
 		for i := range backupCredsResources { // exclude resources already backed up by creds
 			filteredResourceNames = appendUnique(
 				filteredResourceNames,

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -931,8 +931,9 @@ var _ = Describe("BackupSchedule controller", func() {
 					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, //secrets are in the creds backup
 						"secret")).Should(BeTrue())
 
-					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, // resources excluded from backup
-						"clustermanagementaddon.addon.open-cluster-management.io")).Should(BeTrue())
+					// resources excluded from backup should still be allowed to be backed up by the generic backup, if they have a backup label
+					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources,
+						"clustermanagementaddon.addon.open-cluster-management.io")).ShouldNot(BeTrue())
 
 					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, //already in cluster resources backup
 						"klusterletaddonconfig.agent.open-cluster-management.io")).Should(BeTrue())


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12221

Allow resources which are part of the excluded CRDs to be backed up by generic backup, using the backup label.
Currently, the label is ignored if the CRD is part of the excluded list