### PR TITLE
add support for velero restore filter options

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -117,17 +117,52 @@ type RestoreSpec struct {
 	// +optional
 	Hooks veleroapi.RestoreHooks `json:"hooks,omitempty"`
 
-	// ExcludedNamespaces contains a list of namespaces that are not
+	// velero option - IncludedNamespaces is a slice of namespace names to include objects
+	// from. If empty, all namespaces are included.
+	// +optional
+	// +nullable
+	IncludedNamespaces []string `json:"includedNamespaces,omitempty"`
+
+	// velero option - ExcludedNamespaces contains a list of namespaces that are not
 	// included in the restore.
 	// +optional
 	// +nullable
 	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty"`
 
-	// ExcludedResources is a slice of resource names that are not
+	// velero option - IncludedResources is a slice of resource names to include
+	// in the restore. If empty, all resources in the backup are included.
+	// +optional
+	// +nullable
+	IncludedResources []string `json:"includedResources,omitempty"`
+
+	// velero option - ExcludedResources is a slice of resource names that are not
 	// included in the restore.
 	// +optional
 	// +nullable
 	ExcludedResources []string `json:"excludedResources,omitempty"`
+
+	// velero option - LabelSelector is a metav1.LabelSelector to filter with
+	// when restoring individual objects from the backup. If empty
+	// or nil, all objects are included. Optional.
+	// +optional
+	// +nullable
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
+
+	// velero option - OrLabelSelectors is list of metav1.LabelSelector to filter with
+	// when restoring individual objects from the backup. If multiple provided
+	// they will be joined by the OR operator. LabelSelector as well as
+	// OrLabelSelectors cannot co-exist in restore request, only one of them
+	// can be used
+	// +optional
+	// +nullable
+	OrLabelSelectors []*metav1.LabelSelector `json:"orLabelSelectors,omitempty"`
+
+	// velero option - NamespaceMapping is a map of source namespace names
+	// to target namespace names to restore into. Any source
+	// namespaces not included in the map will be restored into
+	// namespaces of the same name.
+	// +optional
+	NamespaceMapping map[string]string `json:"namespaceMapping,omitempty"`
 }
 
 // RestoreStatus defines the observed state of Restore

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -231,8 +232,18 @@ func (in *RestoreSpec) DeepCopyInto(out *RestoreSpec) {
 		**out = **in
 	}
 	in.Hooks.DeepCopyInto(&out.Hooks)
+	if in.IncludedNamespaces != nil {
+		in, out := &in.IncludedNamespaces, &out.IncludedNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExcludedNamespaces != nil {
 		in, out := &in.ExcludedNamespaces, &out.ExcludedNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.IncludedResources != nil {
+		in, out := &in.IncludedResources, &out.IncludedResources
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -240,6 +251,29 @@ func (in *RestoreSpec) DeepCopyInto(out *RestoreSpec) {
 		in, out := &in.ExcludedResources, &out.ExcludedResources
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.LabelSelector != nil {
+		in, out := &in.LabelSelector, &out.LabelSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.OrLabelSelectors != nil {
+		in, out := &in.OrLabelSelectors, &out.OrLabelSelectors
+		*out = make([]*metav1.LabelSelector, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(metav1.LabelSelector)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
+	if in.NamespaceMapping != nil {
+		in, out := &in.NamespaceMapping, &out.NamespaceMapping
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 }
 

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -57,15 +57,15 @@ spec:
                   restoring the new data.
                 type: string
               excludedNamespaces:
-                description: ExcludedNamespaces contains a list of namespaces that
-                  are not included in the restore.
+                description: velero option - ExcludedNamespaces contains a list of
+                  namespaces that are not included in the restore.
                 items:
                   type: string
                 nullable: true
                 type: array
               excludedResources:
-                description: ExcludedResources is a slice of resource names that are
-                  not included in the restore.
+                description: velero option - ExcludedResources is a slice of resource
+                  names that are not included in the restore.
                 items:
                   type: string
                 nullable: true
@@ -1786,6 +1786,131 @@ spec:
                       type: object
                     type: array
                 type: object
+              includedNamespaces:
+                description: velero option - IncludedNamespaces is a slice of namespace
+                  names to include objects from. If empty, all namespaces are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedResources:
+                description: velero option - IncludedResources is a slice of resource
+                  names to include in the restore. If empty, all resources in the
+                  backup are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              labelSelector:
+                description: velero option - LabelSelector is a metav1.LabelSelector
+                  to filter with when restoring individual objects from the backup.
+                  If empty or nil, all objects are included. Optional.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              namespaceMapping:
+                additionalProperties:
+                  type: string
+                description: velero option - NamespaceMapping is a map of source namespace
+                  names to target namespace names to restore into. Any source namespaces
+                  not included in the map will be restored into namespaces of the
+                  same name.
+                type: object
+              orLabelSelectors:
+                description: velero option - OrLabelSelectors is list of metav1.LabelSelector
+                  to filter with when restoring individual objects from the backup.
+                  If multiple provided they will be joined by the OR operator. LabelSelector
+                  as well as OrLabelSelectors cannot co-exist in restore request,
+                  only one of them can be used
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                nullable: true
+                type: array
               preserveNodePorts:
                 description: velero option - PreserveNodePorts specifies whether to
                   restore old nodePorts from backup.

--- a/config/samples/cluster_v1beta1_restore_options.yaml
+++ b/config/samples/cluster_v1beta1_restore_options.yaml
@@ -16,7 +16,7 @@
 # to restore only resources from the managed-cls-1 namespace
 #
 # We strongly recommend to review the cleanupBeforeRestore option and use cleanupBeforeRestore=None when restoring a subset of the data, as 
-#  cleanupBeforeRestore=CleanupRestored would clean up resources on the restore hub which are excluded by your restore filter criteria.
+#  cleanupBeforeRestore=CleanupRestored may clean up resources on the restore hub which are excluded by the restore filter criteria.
 # 
 
 apiVersion: cluster.open-cluster-management.io/v1beta1

--- a/config/samples/cluster_v1beta1_restore_options.yaml
+++ b/config/samples/cluster_v1beta1_restore_options.yaml
@@ -1,6 +1,6 @@
 # This sample shows how to use Velero restore options to filter out the resources to be restored.
 # Follow the https://velero.io/docs/main/api-types/restore/ CRD to find out supported options and how to use them
-# The ACM restore can use the following velero restore options:
+# The ACM restore can use the following velero restore options to filter ACM restored resources:
 # - includedResources
 # - includedNamespaces
 # - excludedResources
@@ -11,9 +11,12 @@
 # - RestoreStatus
 # - Hooks
 # - LabelSelector
-# This sample shows how to use some of the velero restore options when restoring the  ACM hub backup
-# We strongly recommend to review the cleanupBeforeRestore and use cleanupBeforeRestore=None when restoring a subset of the data 
-#    as, CleanupRestored would clean up resources excluded by your restore filter criteria.
+# This sample shows how to use some of the velero restore options when restoring the ACM hub backup to filter out resources to be restored.
+# In this sample we used the includedResources option to restore only ManagedClusters resources, and the includedNamespaces option
+# to restore only resources from the managed-cls-1 namespace
+#
+# We strongly recommend to review the cleanupBeforeRestore option and use cleanupBeforeRestore=None when restoring a subset of the data, as 
+#  cleanupBeforeRestore=CleanupRestored would clean up resources on the restore hub which are excluded by your restore filter criteria.
 # 
 
 apiVersion: cluster.open-cluster-management.io/v1beta1
@@ -22,13 +25,13 @@ metadata:
   name: restore-acm-options
   namespace: open-cluster-management-backup
 spec:
-  cleanupBeforeRestore: None # use None when restoring a subset of the data as, CleanupRestored would clean up resources excluded by your restore filter criteria
+  cleanupBeforeRestore: None # use None when restoring a subset of the data, as CleanupRestored would clean up resources excluded by your restore filter criteria
   veleroManagedClustersBackupName: latest
   veleroCredentialsBackupName: latest
   veleroResourcesBackupName: latest
   includedResources:
     - ManagedClusters # restore only ManagedClusters
-  namespaceMapping:
-    - default: default-new # restore all resources from default ns to default-new ns
+  includedNamespaces:
+    - managed-cls-1 # restore only resources from the managed-cls-1 namespace
 
 

--- a/config/samples/cluster_v1beta1_restore_options.yaml
+++ b/config/samples/cluster_v1beta1_restore_options.yaml
@@ -1,0 +1,34 @@
+# This sample shows how to use Velero restore options to filter out the resources to be restored.
+# Follow the https://velero.io/docs/main/api-types/restore/ CRD to find out supported options and how to use them
+# The ACM restore can use the following velero restore options:
+# - includedResources
+# - includedNamespaces
+# - excludedResources
+# - excludedNamespaces
+# - namespaceMapping
+# - OrLabelSelectors
+# - NamespaceMapping
+# - RestoreStatus
+# - Hooks
+# - LabelSelector
+# This sample shows how to use some of the velero restore options when restoring the  ACM hub backup
+# We strongly recommend to review the cleanupBeforeRestore and use cleanupBeforeRestore=None when restoring a subset of the data 
+#    as, CleanupRestored would clean up resources excluded by your restore filter criteria.
+# 
+
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Restore
+metadata:
+  name: restore-acm-options
+  namespace: open-cluster-management-backup
+spec:
+  cleanupBeforeRestore: None # use None when restoring a subset of the data as, CleanupRestored would clean up resources excluded by your restore filter criteria
+  veleroManagedClustersBackupName: latest
+  veleroCredentialsBackupName: latest
+  veleroResourcesBackupName: latest
+  includedResources:
+    - ManagedClusters # restore only ManagedClusters
+  namespaceMapping:
+    - default: default-new # restore all resources from default ns to default-new ns
+
+

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -376,6 +376,11 @@ func (b *ACMRestoreHelper) restoreLabelSelector(selector *metav1.LabelSelector) 
 	return b
 }
 
+func (b *ACMRestoreHelper) restoreORLabelSelector(selectors []*metav1.LabelSelector) *ACMRestoreHelper {
+	b.object.Spec.OrLabelSelectors = selectors
+	return b
+}
+
 func (b *ACMRestoreHelper) restorePVs(restorePV bool) *ACMRestoreHelper {
 	b.object.Spec.RestorePVs = &restorePV
 	return b

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -371,6 +371,11 @@ func (b *ACMRestoreHelper) preserveNodePorts(preserve bool) *ACMRestoreHelper {
 	return b
 }
 
+func (b *ACMRestoreHelper) restoreLabelSelector(selector *metav1.LabelSelector) *ACMRestoreHelper {
+	b.object.Spec.LabelSelector = selector
+	return b
+}
+
 func (b *ACMRestoreHelper) restorePVs(restorePV bool) *ACMRestoreHelper {
 	b.object.Spec.RestorePVs = &restorePV
 	return b
@@ -397,8 +402,23 @@ func (b *ACMRestoreHelper) excludedResources(resources []string) *ACMRestoreHelp
 	return b
 }
 
+func (b *ACMRestoreHelper) includedResources(resources []string) *ACMRestoreHelper {
+	b.object.Spec.IncludedResources = resources
+	return b
+}
+
 func (b *ACMRestoreHelper) excludedNamespaces(nspaces []string) *ACMRestoreHelper {
 	b.object.Spec.ExcludedNamespaces = nspaces
+	return b
+}
+
+func (b *ACMRestoreHelper) includedNamespaces(nspaces []string) *ACMRestoreHelper {
+	b.object.Spec.IncludedNamespaces = nspaces
+	return b
+}
+
+func (b *ACMRestoreHelper) namespaceMapping(nspaces map[string]string) *ACMRestoreHelper {
+	b.object.Spec.NamespaceMapping = nspaces
 	return b
 }
 

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -796,7 +796,8 @@ func setUserRestoreFilters(
 		}
 
 		// append LabelSelector resources since the acm restore uses the veleroRestore.Spec.LabelSelector
-		// to filter out activation resources when restoring the data - as it does for credentials-active restore, using the cluster.open-cluster-management.io/backup=cluster-activation label
+		// to filter out activation resources when restoring the data - as it does for credentials-active restore,
+		// using the cluster.open-cluster-management.io/backup=cluster-activation label
 		// we want to keep any acm predefined veleroRestore.Spec.LabelSelector and add to those the user defined ones
 
 		// set MatchExpressions

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -804,8 +804,6 @@ func setOptionalProperties(
 				veleroRestore.Spec.LabelSelector.MatchLabels = matchlabels
 			}
 
-			// append suer defined OrLabelSelector values to the restore OrLabelSelector
-			// to keep any predefined OrLabelSelector values
 			maps.Copy(veleroRestore.Spec.LabelSelector.MatchLabels, acmRestore.Spec.LabelSelector.MatchLabels)
 		}
 	}
@@ -818,6 +816,8 @@ func setOptionalProperties(
 			veleroRestore.Spec.OrLabelSelectors = labels
 		}
 
+		// append user defined OrLabelSelector values to the restore OrLabelSelector
+		// to keep any predefined OrLabelSelector values
 		veleroRestore.Spec.OrLabelSelectors = append(veleroRestore.Spec.OrLabelSelectors, acmRestore.Spec.OrLabelSelectors...)
 
 	}

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -743,6 +743,7 @@ func setOptionalProperties(
 	acmRestore *v1beta1.Restore,
 	veleroRestore *veleroapi.Restore,
 ) {
+
 	// set includeClusterResources for all restores except credentials
 	if key == Resources || key == ManagedClusters || key == ResourcesGeneric {
 		var clusterResource bool = true
@@ -770,6 +771,21 @@ func setOptionalProperties(
 			acmRestore.Spec.Hooks.Resources...,
 		)
 	}
+
+	// set user options for resource filtering
+	setUserRestoreFilters(acmRestore, veleroRestore)
+
+	// allow namespace mapping
+	if acmRestore.Spec.NamespaceMapping != nil {
+		veleroRestore.Spec.NamespaceMapping = acmRestore.Spec.NamespaceMapping
+	}
+}
+
+// set user options for resource filtering
+func setUserRestoreFilters(
+	acmRestore *v1beta1.Restore,
+	veleroRestore *veleroapi.Restore,
+) {
 
 	// add any label selector set using the acm restore resource spec
 	if acmRestore.Spec.LabelSelector != nil {
@@ -860,10 +876,5 @@ func setOptionalProperties(
 				acmRestore.Spec.IncludedResources[i])
 		}
 
-	}
-
-	// allow namespace mapping
-	if acmRestore.Spec.NamespaceMapping != nil {
-		veleroRestore.Spec.NamespaceMapping = acmRestore.Spec.NamespaceMapping
 	}
 }

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -206,6 +206,19 @@ var _ = Describe("Basic Restore controller", func() {
 			req2,
 		}
 
+		restoreOrSelector := []*metav1.LabelSelector{
+			{
+				MatchLabels: map[string]string{
+					"restore-test-1": "restore-test-1-value",
+				},
+			},
+			{
+				MatchLabels: map[string]string{
+					"restore-test-2": "restore-test-2-value",
+				},
+			},
+		}
+
 		managedClusterNamespaces = []corev1.Namespace{}
 		rhacmRestore = *createACMRestore(restoreName, veleroNamespace.Name).
 			cleanupBeforeRestore(v1beta1.CleanupTypeRestored).syncRestoreWithNewBackups(true).
@@ -232,6 +245,7 @@ var _ = Describe("Basic Restore controller", func() {
 				},
 				MatchExpressions: matchExpressions,
 			}).
+			restoreORLabelSelector(restoreOrSelector).
 			veleroResourcesBackupName(veleroResourcesBackupName).object
 	})
 
@@ -346,13 +360,14 @@ var _ = Describe("Basic Restore controller", func() {
 					ContainElement("res4"))
 				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchLabels["restorelabel"]).Should(
 					BeIdenticalTo("value"))
-				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchLabels["restorelabel1"]).Should(
-					BeIdenticalTo("value1"))
 				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchExpressions).Should(
 					ContainElement(req1))
 				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchExpressions).Should(
 					ContainElement(req2))
-
+				Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[0].MatchLabels["restore-test-1"]).Should(
+					BeIdenticalTo("restore-test-1-value"))
+				Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[1].MatchLabels["restore-test-2"]).Should(
+					BeIdenticalTo("restore-test-2-value"))
 				_, found := find(backupNames, veleroRestores.Items[i].Spec.BackupName)
 				Expect(found).Should(BeTrue())
 

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -190,6 +190,22 @@ var _ = Describe("Basic Restore controller", func() {
 				object,
 		}
 
+		req1 := metav1.LabelSelectorRequirement{
+			Key:      "foo",
+			Operator: metav1.LabelSelectorOperator("In"),
+			Values:   []string{"bar"},
+		}
+		req2 := metav1.LabelSelectorRequirement{
+			Key:      "foo2",
+			Operator: metav1.LabelSelectorOperator("NotIn"),
+			Values:   []string{"bar2"},
+		}
+
+		matchExpressions := []metav1.LabelSelectorRequirement{
+			req1,
+			req2,
+		}
+
 		managedClusterNamespaces = []corev1.Namespace{}
 		rhacmRestore = *createACMRestore(restoreName, veleroNamespace.Name).
 			cleanupBeforeRestore(v1beta1.CleanupTypeRestored).syncRestoreWithNewBackups(true).
@@ -205,7 +221,17 @@ var _ = Describe("Basic Restore controller", func() {
 				veleroapi.RestoreResourceHookSpec{Name: "hookName"},
 			}).
 			excludedResources([]string{"res1", "res2"}).
+			includedResources([]string{"res3", "res4"}).
 			excludedNamespaces([]string{"ns1", "ns2"}).
+			namespaceMapping(map[string]string{"ns3": "map-ns3"}).
+			includedNamespaces([]string{"ns3", "ns4"}).
+			restoreLabelSelector(&metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"restorelabel":  "value",
+					"restorelabel1": "value1",
+				},
+				MatchExpressions: matchExpressions,
+			}).
 			veleroResourcesBackupName(veleroResourcesBackupName).object
 	})
 
@@ -282,6 +308,17 @@ var _ = Describe("Basic Restore controller", func() {
 				return len(veleroRestores.Items)
 			}, timeout, interval).Should(Equal(len(backupNames)))
 
+			req1 := metav1.LabelSelectorRequirement{
+				Key:      "foo",
+				Operator: metav1.LabelSelectorOperator("In"),
+				Values:   []string{"bar"},
+			}
+			req2 := metav1.LabelSelectorRequirement{
+				Key:      "foo2",
+				Operator: metav1.LabelSelectorOperator("NotIn"),
+				Values:   []string{"bar2"},
+			}
+
 			restoreNames := []string{}
 			for i := range backupNames {
 				// look for velero optional properties
@@ -293,9 +330,29 @@ var _ = Describe("Basic Restore controller", func() {
 					BeIdenticalTo("hookName"))
 				Expect(veleroRestores.Items[i].Spec.ExcludedNamespaces).Should(
 					ContainElement("ns1"))
+				Expect(veleroRestores.Items[i].Spec.IncludedNamespaces).Should(
+					ContainElement("ns3"))
+				Expect(veleroRestores.Items[i].Spec.NamespaceMapping["ns3"]).Should(
+					BeIdenticalTo("map-ns3"))
+				Expect(veleroRestores.Items[i].Spec.IncludedNamespaces).Should(
+					ContainElement("ns4"))
+				Expect(veleroRestores.Items[i].Spec.IncludedNamespaces).Should(
+					ContainElement("ns4"))
 				Expect(veleroRestores.Items[i].Spec.ExcludedResources).Should(
 					ContainElement("res1"))
-				//
+				Expect(veleroRestores.Items[i].Spec.IncludedResources).Should(
+					ContainElement("res3"))
+				Expect(veleroRestores.Items[i].Spec.IncludedResources).Should(
+					ContainElement("res4"))
+				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchLabels["restorelabel"]).Should(
+					BeIdenticalTo("value"))
+				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchLabels["restorelabel1"]).Should(
+					BeIdenticalTo("value1"))
+				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchExpressions).Should(
+					ContainElement(req1))
+				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchExpressions).Should(
+					ContainElement(req2))
+
 				_, found := find(backupNames, veleroRestores.Items[i].Spec.BackupName)
 				Expect(found).Should(BeTrue())
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12973

Enable ACM restore support for the following velero restore options:
see https://velero.io/docs/main/api-types/restore/ CRD
- includedResources
- includedNamespaces
- OrLabelSelectors
- LabelSelector
- namespaceMapping

Added a sample that shows how to use some of the velero restore options when restoring the  ACM hub backup
We strongly recommend to review the cleanupBeforeRestore option and use cleanupBeforeRestore=None when restoring a subset of the data, as using cleanupBeforeRestore=CleanupRestored may clean up resources excluded by the restore filter criteria.
