### PR TITLE
ignore orLabelSelector for credentials and generic resources restore

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -773,7 +773,7 @@ func setOptionalProperties(
 	}
 
 	// set user options for resource filtering
-	setUserRestoreFilters(acmRestore, veleroRestore)
+	setUserRestoreFilters(acmRestore, veleroRestore, key)
 
 	// allow namespace mapping
 	if acmRestore.Spec.NamespaceMapping != nil {
@@ -785,6 +785,7 @@ func setOptionalProperties(
 func setUserRestoreFilters(
 	acmRestore *v1beta1.Restore,
 	veleroRestore *veleroapi.Restore,
+	key ResourceType,
 ) {
 
 	// add any label selector set using the acm restore resource spec
@@ -826,7 +827,9 @@ func setUserRestoreFilters(
 	}
 
 	// add any or label selector set using the acm restore resource spec
-	if acmRestore.Spec.OrLabelSelectors != nil {
+	// skip resources generic and credentials since they already define a LabelSelector for cluster activation
+	// LabelSelector and OrLabelSelectors are mutually exclusive
+	if (key != ResourcesGeneric && key != Credentials) && acmRestore.Spec.OrLabelSelectors != nil {
 
 		if veleroRestore.Spec.OrLabelSelectors == nil {
 			labels := []*v1.LabelSelector{}


### PR DESCRIPTION
Related to https://github.com/stolostron/cluster-backup-operator/pull/650

https://issues.redhat.com/browse/ACM-12973

Changes:
When the orLabelSelector is used to filter out restored objects, the orLabelSelector will be ignored for the credentials and generic resources velero restore files, since they already use a labelSelector ( set by the backup operator ) to filter out resources with a cluster-activation label
LabelSelector and OrLabelSelectors are mutually exclusive so you can't use both

labelSelector set by ACM on the velero restore resource for credentials and generic resources:

```
  labelSelector:
    matchExpressions:
      - key: cluster.open-cluster-management.io/backup
        operator: In
        values:
          - cluster-activation
```