### PR TITLE
append activation label selector to user defined OrLabelSelector

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -291,6 +291,16 @@ func createRestore(name string, ns string) *RestoreHelper {
 	}
 }
 
+func (b *RestoreHelper) labelSelector(selector *metav1.LabelSelector) *RestoreHelper {
+	b.object.Spec.LabelSelector = selector
+	return b
+}
+
+func (b *RestoreHelper) orLabelSelector(selectors []*metav1.LabelSelector) *RestoreHelper {
+	b.object.Spec.OrLabelSelectors = selectors
+	return b
+}
+
 func (b *RestoreHelper) backupName(name string) *RestoreHelper {
 	b.object.Spec.BackupName = name
 	return b

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -773,7 +773,7 @@ func setOptionalProperties(
 	}
 
 	// set user options for resource filtering
-	setUserRestoreFilters(acmRestore, veleroRestore, key)
+	setUserRestoreFilters(acmRestore, veleroRestore)
 
 	// allow namespace mapping
 	if acmRestore.Spec.NamespaceMapping != nil {
@@ -785,7 +785,6 @@ func setOptionalProperties(
 func setUserRestoreFilters(
 	acmRestore *v1beta1.Restore,
 	veleroRestore *veleroapi.Restore,
-	key ResourceType,
 ) {
 
 	// add any label selector set using the acm restore resource spec
@@ -827,20 +826,14 @@ func setUserRestoreFilters(
 	}
 
 	// add any or label selector set using the acm restore resource spec
-	// skip resources generic and credentials since they already define a LabelSelector for cluster activation
-	// LabelSelector and OrLabelSelectors are mutually exclusive
-	if (key != ResourcesGeneric && key != Credentials) && acmRestore.Spec.OrLabelSelectors != nil {
-
-		if veleroRestore.Spec.OrLabelSelectors == nil {
-			labels := []*v1.LabelSelector{}
-			veleroRestore.Spec.OrLabelSelectors = labels
-		}
-
-		// append user defined OrLabelSelector values to the restore OrLabelSelector
-		// to keep any predefined OrLabelSelector values
-		veleroRestore.Spec.OrLabelSelectors = append(veleroRestore.Spec.OrLabelSelectors, acmRestore.Spec.OrLabelSelectors...)
-
+	if veleroRestore.Spec.OrLabelSelectors == nil {
+		labels := []*v1.LabelSelector{}
+		veleroRestore.Spec.OrLabelSelectors = labels
 	}
+
+	// append user defined OrLabelSelector values to the restore OrLabelSelector
+	// to keep any predefined OrLabelSelector values
+	veleroRestore.Spec.OrLabelSelectors = append(veleroRestore.Spec.OrLabelSelectors, acmRestore.Spec.OrLabelSelectors...)
 
 	// allow excluding namespaces
 	if acmRestore.Spec.ExcludedNamespaces != nil {

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -19,14 +19,12 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"maps"
 	"sort"
 	"strings"
 
 	"github.com/go-logr/logr"
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -788,52 +786,8 @@ func setUserRestoreFilters(
 ) {
 
 	// add any label selector set using the acm restore resource spec
-	if acmRestore.Spec.LabelSelector != nil {
-
-		if veleroRestore.Spec.LabelSelector == nil {
-			labels := &v1.LabelSelector{}
-			veleroRestore.Spec.LabelSelector = labels
-		}
-
-		// append LabelSelector resources since the acm restore uses the veleroRestore.Spec.LabelSelector
-		// to filter out activation resources when restoring the data - as it does for credentials-active restore,
-		// using the cluster.open-cluster-management.io/backup=cluster-activation label
-		// we want to keep any acm predefined veleroRestore.Spec.LabelSelector and add to those the user defined ones
-
-		// set MatchExpressions
-		if acmRestore.Spec.LabelSelector.MatchExpressions != nil {
-			// create the MatchExpression for the velero resource, if not defined yet
-			if veleroRestore.Spec.LabelSelector.MatchExpressions == nil {
-				requirements := make([]v1.LabelSelectorRequirement, 0)
-				veleroRestore.Spec.LabelSelector.MatchExpressions = requirements
-			}
-
-			veleroRestore.Spec.LabelSelector.MatchExpressions = append(veleroRestore.Spec.LabelSelector.MatchExpressions,
-				acmRestore.Spec.LabelSelector.MatchExpressions...,
-			)
-		}
-
-		// set MatchLabels
-		if acmRestore.Spec.LabelSelector.MatchLabels != nil {
-			// create the MatchLabels for the velero resource, if not defined yet
-			if veleroRestore.Spec.LabelSelector.MatchLabels == nil {
-				matchlabels := make(map[string]string, 0)
-				veleroRestore.Spec.LabelSelector.MatchLabels = matchlabels
-			}
-
-			maps.Copy(veleroRestore.Spec.LabelSelector.MatchLabels, acmRestore.Spec.LabelSelector.MatchLabels)
-		}
-	}
-
-	// add any or label selector set using the acm restore resource spec
-	if veleroRestore.Spec.OrLabelSelectors == nil {
-		labels := []*v1.LabelSelector{}
-		veleroRestore.Spec.OrLabelSelectors = labels
-	}
-
-	// append user defined OrLabelSelector values to the restore OrLabelSelector
-	// to keep any predefined OrLabelSelector values
-	veleroRestore.Spec.OrLabelSelectors = append(veleroRestore.Spec.OrLabelSelectors, acmRestore.Spec.OrLabelSelectors...)
+	veleroRestore.Spec.LabelSelector = acmRestore.Spec.LabelSelector
+	veleroRestore.Spec.OrLabelSelectors = acmRestore.Spec.OrLabelSelectors
 
 	// allow excluding namespaces
 	if acmRestore.Spec.ExcludedNamespaces != nil {

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -434,21 +434,12 @@ func (r *RestoreReconciler) initVeleroRestores(
 			veleroRestoresToCreate[ManagedClusters] == nil {
 			// if restoring the resources but not the managed clusters,
 			// do not restore generic resources in the activation stage
-			if restoreObj.Spec.LabelSelector == nil {
-				labels := &metav1.LabelSelector{}
-				restoreObj.Spec.LabelSelector = labels
-
-				requirements := make([]metav1.LabelSelectorRequirement, 0)
-				restoreObj.Spec.LabelSelector.MatchExpressions = requirements
-			}
 			req := &metav1.LabelSelectorRequirement{}
 			req.Key = backupCredsClusterLabel
 			req.Operator = "NotIn"
 			req.Values = []string{ClusterActivationLabel}
-			restoreObj.Spec.LabelSelector.MatchExpressions = append(
-				restoreObj.Spec.LabelSelector.MatchExpressions,
-				*req,
-			)
+
+			addRestoreLabelSelector(restoreObj, *req)
 		}
 
 		isCredsClsOnActiveStep := updateLabelsForActiveResources(restore, key, veleroRestoresToCreate)
@@ -528,21 +519,14 @@ func updateLabelsForActiveResources(
 
 		// if restoring the ManagedClusters need to restore the credentials resources for the activation phase
 		// if managed clusters are restored, then need to restore the credentials to get active resources
-		if restoreObj.Spec.LabelSelector == nil {
-			labels := &metav1.LabelSelector{}
-			restoreObj.Spec.LabelSelector = labels
 
-			requirements := make([]metav1.LabelSelectorRequirement, 0)
-			restoreObj.Spec.LabelSelector.MatchExpressions = requirements
-		}
 		req := &metav1.LabelSelectorRequirement{}
 		req.Key = backupCredsClusterLabel
 		req.Operator = "In"
 		req.Values = []string{ClusterActivationLabel}
-		restoreObj.Spec.LabelSelector.MatchExpressions = append(
-			restoreObj.Spec.LabelSelector.MatchExpressions,
-			*req,
-		)
+
+		addRestoreLabelSelector(restoreObj, *req)
+
 		// use a different name for this activation restore; if this Restore was run using the sync operation,
 		// the generic and credentials restore for this backup name already exist
 		if (key == ResourcesGeneric && *restore.Spec.VeleroResourcesBackupName != skipRestoreStr) ||

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Basic Restore controller", func() {
 				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchExpressions).Should(
 					ContainElement(req2))
 
-				// anything but credentials and resources-generic restore files should use the OrLabelSelectors
+				// should use the OrLabelSelectors
 				Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[0].MatchLabels["restore-test-1"]).Should(
 					BeIdenticalTo("restore-test-1-value"))
 				Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[1].MatchLabels["restore-test-2"]).Should(

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -366,20 +365,11 @@ var _ = Describe("Basic Restore controller", func() {
 				Expect(veleroRestores.Items[i].Spec.LabelSelector.MatchExpressions).Should(
 					ContainElement(req2))
 
-				if !strings.Contains(veleroRestores.Items[i].Name, veleroScheduleNames[Credentials]) &&
-					!strings.Contains(veleroRestores.Items[i].Name, veleroScheduleNames[ResourcesGeneric]) {
-					// anything but credentials and resources-generic restore files should use the OrLabelSelectors
-					Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[0].MatchLabels["restore-test-1"]).Should(
-						BeIdenticalTo("restore-test-1-value"))
-					Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[1].MatchLabels["restore-test-2"]).Should(
-						BeIdenticalTo("restore-test-2-value"))
-				} else {
-					// credentials and resources-generic restore files should ignore OrLabelSelectors
-					// because they are already using the LabelSelectors to filter activation-resources
-					// LabelSelector and OrLabelSelectors are mutually exclusive
-					Expect(veleroRestores.Items[i].Spec.OrLabelSelectors).Should(BeEmpty())
-					Expect(veleroRestores.Items[i].Spec.OrLabelSelectors).Should(BeEmpty())
-				}
+				// anything but credentials and resources-generic restore files should use the OrLabelSelectors
+				Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[0].MatchLabels["restore-test-1"]).Should(
+					BeIdenticalTo("restore-test-1-value"))
+				Expect(veleroRestores.Items[i].Spec.OrLabelSelectors[1].MatchLabels["restore-test-2"]).Should(
+					BeIdenticalTo("restore-test-2-value"))
 
 				_, found := find(backupNames, veleroRestores.Items[i].Spec.BackupName)
 				Expect(found).Should(BeTrue())

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -413,7 +413,9 @@ func isCRDNotPresentError(err error) bool {
 }
 
 // append requirement if it doesn't exist
-func appendUniqueReq(requirements []metav1.LabelSelectorRequirement, req metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
+func appendUniqueReq(requirements []metav1.LabelSelectorRequirement,
+	req metav1.LabelSelectorRequirement,
+) []metav1.LabelSelectorRequirement {
 
 	exists := false
 	for idx := range requirements {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -412,11 +412,11 @@ func isCRDNotPresentError(err error) bool {
 	return false
 }
 
-// add restore label selector requirement - like cluster activation label requirement, for credentials and generis resources restore files
-// This will be added to the user defined restore filters with the following rule:
-// 1. if the user defines a set of OrLabelSelectors, the req LabelSelectorRequirement will be injected
-// to each OrLabelSelectors MatchExpression ( will run as an AND rule on each MatchExpression).
-// 2. if the user defines a LabelSelector, the req LabelSelectorRequirement will be appeded to each of the OR MatchExpressions ( ANDed)
+// add any restore label selector requirement (like cluster activation label requirement, for credentials and generis resources restore files)
+// This will be appended to any user defined restore filters with the following rule:
+// 1. if the user defines a set of OrLabelSelectors rules, the req LabelSelectorRequirement will be injected
+// to each OrLabelSelectors MatchExpression (will run as an AND rule on each MatchExpression).
+// 2. if the user defines a LabelSelector, the req LabelSelectorRequirement will be appeded to each of the OR MatchExpressions (ANDed)
 // 3. If the user doesn't define a LabelSelector or a OrLabelSelectors, the req Requirement will be created as a LabelSelector option
 func addRestoreLabelSelector(
 	restoreObj *veleroapi.Restore,

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -412,7 +412,7 @@ func isCRDNotPresentError(err error) bool {
 	return false
 }
 
-// add any restore label selector requirement (like cluster activation label requirement, for credentials and generis resources restore files)
+// add any restore label selector requirement (like cluster activation label requirement, for credentials and generic resources restore files)
 // This will be appended to any user defined restore filters with the following rule:
 // 1. if the user defines a set of OrLabelSelectors rules, the req LabelSelectorRequirement will be injected
 // to each OrLabelSelectors MatchExpression (will run as an AND rule on each MatchExpression).

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -409,4 +410,39 @@ func isCRDNotPresentError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// add restore label selector requirement - like cluster activation label requirement, for credentials and generis resources restore files
+// This will be added to the user defined restore filters with the following rule:
+// 1. if the user defines a set of OrLabelSelectors, the req LabelSelectorRequirement will be injected
+// to each OrLabelSelectors MatchExpression ( will run as an AND rule on each MatchExpression).
+// 2. if the user defines a LabelSelector, the req LabelSelectorRequirement will be appeded to each of the OR MatchExpressions ( ANDed)
+// 3. If the user doesn't define a LabelSelector or a OrLabelSelectors, the req Requirement will be created as a LabelSelector option
+func addRestoreLabelSelector(
+	restoreObj *veleroapi.Restore,
+	req metav1.LabelSelectorRequirement,
+) {
+
+	if restoreObj.Spec.OrLabelSelectors != nil && len(restoreObj.Spec.OrLabelSelectors) > 0 {
+		// LabelSelector and OrLabelSelectors are mutually exclusive
+		// if restoreObj.Spec.OrLabelSelectors is not null, add LabelSelectors match expressions ( which are ANDed ) to each of the
+		// OrLabelSelectors expressions ( which are also ANDed )
+		for i := range restoreObj.Spec.OrLabelSelectors {
+			restoreObj.Spec.OrLabelSelectors[i].MatchExpressions = append(restoreObj.Spec.OrLabelSelectors[i].MatchExpressions,
+				req)
+		}
+	} else {
+		// if no OrLabelSelector, add the MatchExpression to the LabelSelector
+		if restoreObj.Spec.LabelSelector == nil {
+			labels := &metav1.LabelSelector{}
+			restoreObj.Spec.LabelSelector = labels
+
+			requirements := make([]metav1.LabelSelectorRequirement, 0)
+			restoreObj.Spec.LabelSelector.MatchExpressions = requirements
+		}
+		restoreObj.Spec.LabelSelector.MatchExpressions = append(
+			restoreObj.Spec.LabelSelector.MatchExpressions,
+			req,
+		)
+	}
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -412,12 +412,33 @@ func isCRDNotPresentError(err error) bool {
 	return false
 }
 
-// add any restore label selector requirement (like cluster activation label requirement, for credentials and generic resources restore files)
+// append requirement if it doesn't exist
+func appendUniqueReq(requirements []metav1.LabelSelectorRequirement, req metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
+
+	exists := false
+	for idx := range requirements {
+
+		if requirements[idx].Key == req.Key {
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		requirements = append(requirements, req)
+	}
+
+	return requirements
+}
+
+// add any restore label selector requirement (like cluster activation label requirement,
+// for credentials and generic resources restore files)
 // This will be appended to any user defined restore filters with the following rule:
 // 1. if the user defines a set of OrLabelSelectors rules, the req LabelSelectorRequirement will be injected
 // to each OrLabelSelectors MatchExpression (will run as an AND rule on each MatchExpression).
-// 2. if the user defines a LabelSelector, the req LabelSelectorRequirement will be appeded to each of the OR MatchExpressions (ANDed)
-// 3. If the user doesn't define a LabelSelector or a OrLabelSelectors, the req Requirement will be created as a LabelSelector option
+// 2. if the user defines a LabelSelector, the req LabelSelectorRequirement
+// will be appeded to each of the OR MatchExpressions (ANDed)
+// 3. If the user doesn't define a LabelSelector or a OrLabelSelectors, the req Requirement
+// will be created as a LabelSelector option
 func addRestoreLabelSelector(
 	restoreObj *veleroapi.Restore,
 	req metav1.LabelSelectorRequirement,
@@ -425,11 +446,12 @@ func addRestoreLabelSelector(
 
 	if restoreObj.Spec.OrLabelSelectors != nil && len(restoreObj.Spec.OrLabelSelectors) > 0 {
 		// LabelSelector and OrLabelSelectors are mutually exclusive
-		// if restoreObj.Spec.OrLabelSelectors is not null, add LabelSelectors match expressions ( which are ANDed ) to each of the
+		// if restoreObj.Spec.OrLabelSelectors is not null,
+		// add LabelSelectors match expressions ( which are ANDed ) to each of the
 		// OrLabelSelectors expressions ( which are also ANDed )
 		for i := range restoreObj.Spec.OrLabelSelectors {
-			restoreObj.Spec.OrLabelSelectors[i].MatchExpressions = append(restoreObj.Spec.OrLabelSelectors[i].MatchExpressions,
-				req)
+			restoreObj.Spec.OrLabelSelectors[i].MatchExpressions =
+				appendUniqueReq(restoreObj.Spec.OrLabelSelectors[i].MatchExpressions, req)
 		}
 	} else {
 		// if no OrLabelSelector, add the MatchExpression to the LabelSelector
@@ -440,7 +462,7 @@ func addRestoreLabelSelector(
 			requirements := make([]metav1.LabelSelectorRequirement, 0)
 			restoreObj.Spec.LabelSelector.MatchExpressions = requirements
 		}
-		restoreObj.Spec.LabelSelector.MatchExpressions = append(
+		restoreObj.Spec.LabelSelector.MatchExpressions = appendUniqueReq(
 			restoreObj.Spec.LabelSelector.MatchExpressions,
 			req,
 		)

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -673,3 +673,305 @@ func Test_VeleroCRDsPresent(t *testing.T) {
 		}
 	})
 }
+
+func labelSelectorArrayEqual(a []*v1.LabelSelector, b []v1.LabelSelector) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if !labelSelectorEqual(v, &b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func labelSelectorEqual(a *v1.LabelSelector, b *v1.LabelSelector) bool {
+
+	if a == nil && b == nil {
+		return true
+	}
+
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return true
+	}
+
+	al := a.MatchLabels
+	bl := b.MatchLabels
+
+	if al == nil || bl == nil {
+		return true
+	}
+
+	for key, value := range al {
+		if value != bl[key] {
+			// match labels should be equal
+			return false
+		}
+	}
+
+	// validate MatchExpressions
+	ma := a.MatchExpressions
+	mb := b.MatchExpressions
+
+	if ma == nil && mb == nil {
+		return true
+	}
+
+	if (ma == nil && mb != nil) || (mb == nil && ma != nil) {
+		return false
+	}
+
+	for i, v := range ma {
+		if v.Key != mb[i].Key || v.Operator != mb[i].Operator || !sortCompare(v.Values, mb[i].Values) {
+			return false
+		}
+	}
+	return true
+}
+
+func Test_addRestoreLabelSelector(t *testing.T) {
+	type args struct {
+		veleroRestore *veleroapi.Restore
+		labelSelector metav1.LabelSelectorRequirement
+	}
+
+	emptyLabelSelector := make([]v1.LabelSelector, 0)
+
+	clusterActivationReq := metav1.LabelSelectorRequirement{}
+	clusterActivationReq.Key = backupCredsClusterLabel
+	clusterActivationReq.Operator = "NotIn"
+	clusterActivationReq.Values = []string{ClusterActivationLabel}
+
+	req1 := metav1.LabelSelectorRequirement{
+		Key:      "foo",
+		Operator: metav1.LabelSelectorOperator("In"),
+		Values:   []string{"bar"},
+	}
+	req2 := metav1.LabelSelectorRequirement{
+		Key:      "foo2",
+		Operator: metav1.LabelSelectorOperator("NotIn"),
+		Values:   []string{"bar2"},
+	}
+	req3 := metav1.LabelSelectorRequirement{
+		Key:      "foo3",
+		Operator: metav1.LabelSelectorOperator("NotIn"),
+		Values:   []string{"bar3"},
+	}
+
+	tests := []struct {
+		name                string
+		args                args
+		wantOrLabelSelector []v1.LabelSelector
+		wantLabelSelector   v1.LabelSelector
+	}{
+		{
+			name: "no user defined orLabelSelector or LabelSelector, get empty match expressions",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					object,
+				labelSelector: metav1.LabelSelectorRequirement{},
+			},
+			wantOrLabelSelector: emptyLabelSelector,
+			wantLabelSelector:   v1.LabelSelector{},
+		},
+		{
+			name: "no user defined orLabelSelector or LabelSelector, just create cluster activation LabelSelector",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					object,
+				labelSelector: clusterActivationReq,
+			},
+			wantOrLabelSelector: emptyLabelSelector,
+			wantLabelSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					clusterActivationReq,
+				},
+			},
+		},
+		{
+			name: "using user defined orLabelSelector, so add cluster activation LabelSelector to it",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					orLabelSelector([]*metav1.LabelSelector{
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req1,
+								req2,
+							},
+						},
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req3,
+							},
+						},
+					}).
+					object,
+				labelSelector: clusterActivationReq,
+			},
+			wantOrLabelSelector: []metav1.LabelSelector{
+				metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						req1,
+						req2,
+						clusterActivationReq,
+					},
+				},
+				metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						req3,
+						clusterActivationReq,
+					},
+				},
+			},
+			wantLabelSelector: v1.LabelSelector{},
+		},
+		{
+			name: "using user defined orLabelSelector, no cluster activation LabelSelector",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					orLabelSelector([]*metav1.LabelSelector{
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req1,
+								req2,
+							},
+						},
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req3,
+							},
+						},
+					}).
+					object,
+				labelSelector: metav1.LabelSelectorRequirement{},
+			},
+			wantOrLabelSelector: []metav1.LabelSelector{
+				metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						req1,
+						req2,
+					},
+				},
+				metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						req3,
+					},
+				},
+			},
+			wantLabelSelector: v1.LabelSelector{},
+		},
+		{
+			name: "using user defined LabelSelector, set cluster activation LabelSelectors as usual",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					labelSelector(
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req1,
+								req2,
+							},
+						},
+					).
+					object,
+				labelSelector: clusterActivationReq,
+			},
+			wantOrLabelSelector: emptyLabelSelector,
+			wantLabelSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					req1,
+					req2,
+					clusterActivationReq,
+				},
+			},
+		},
+		{
+			name: "using user defined LabelSelector, no activation LabelSelectors",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					labelSelector(
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req1,
+								req2,
+							},
+						},
+					).
+					object,
+				labelSelector: metav1.LabelSelectorRequirement{},
+			},
+			wantOrLabelSelector: emptyLabelSelector,
+			wantLabelSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					req1,
+					req2,
+				},
+			},
+		},
+		{
+			// this is is going to be flagged as a validation error by velero so this is not really a valid usecase
+			// the user can set both, still, so verifing that the cluster activation LabelSelector goes to the orLabelSelector in this case
+			name: "using both user defined orLabelSelector and LabelSelector, add cluster activation LabelSelector to orLabelSelector",
+			args: args{
+				veleroRestore: createRestore("restore", "restore-ns").
+					orLabelSelector([]*metav1.LabelSelector{
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req1,
+								req2,
+							},
+						},
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req3,
+							},
+						},
+					}).
+					labelSelector(
+						&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								req3,
+							},
+						},
+					).
+					object,
+				labelSelector: clusterActivationReq,
+			},
+			wantOrLabelSelector: []metav1.LabelSelector{
+				metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						req1,
+						req2,
+						clusterActivationReq,
+					},
+				},
+				metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						req3,
+						clusterActivationReq,
+					},
+				},
+			},
+			wantLabelSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					req3,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addRestoreLabelSelector(tt.args.veleroRestore, tt.args.labelSelector)
+
+			if !labelSelectorArrayEqual(tt.args.veleroRestore.Spec.OrLabelSelectors, tt.wantOrLabelSelector) {
+				t.Errorf("OrLabelSelectors not as expected  = %v, want %v got=%v", tt.name, tt.wantOrLabelSelector, tt.args.veleroRestore.Spec.OrLabelSelectors)
+			}
+
+			if !labelSelectorEqual(tt.args.veleroRestore.Spec.LabelSelector, &tt.wantLabelSelector) {
+				t.Errorf("LabelSelector not as expected  = %v, want %v got=%v", tt.name, tt.wantLabelSelector, tt.args.veleroRestore.Spec.LabelSelector)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12973

Related to
https://github.com/stolostron/cluster-backup-operator/pull/655 
https://github.com/stolostron/cluster-backup-operator/pull/650

Updates:
Allow using user defined OrLabelSelectors for restore files where the acm restore already defines a LabelSelector criteria. That would be for credentials and generic resources restore files, both using a LabelSelector to include or exclude cluster activation resources, based on the type or restore ( restore passive or active resources )

For the case when ACM defines a LabelSelector criteria for the velero restore, this is appended to the user defined selectors with the following rules
1. if the user defines a set of OrLabelSelectors rules, the req LabelSelectorRequirement will be injected
to each OrLabelSelectors MatchExpression (will run as an AND rule on each MatchExpression).
2. if the user defines a LabelSelector, the req LabelSelectorRequirement will be appended to each of the OR MatchExpressions (ANDed)
3. If the user doesn't define a LabelSelector or a OrLabelSelectors, the req Requirement will be created as a LabelSelector option


Examples:

1. if the user defines an OR rule 

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Restore
metadata:
  name: restore-gh-move-clusters-step1
  namespace: open-cluster-management-backup
spec:
  cleanupBeforeRestore: None # don't clean up anything, just apply the restore
  veleroCredentialsBackupName: latest
  veleroResourcesBackupName: latest
  veleroManagedClustersBackupName: skip
  orLabelSelectors: 
    - matchExpressions:
        - values:
            - vb-managed-cls
          key: name
          operator: In
```

the resulted Restore would be ( for the acm-resources-generic-schedule )

```
spec:
  scheduleName: acm-resources-generic-schedule
  orLabelSelectors:
    - matchExpressions:
        - key: name
          operator: In
          values:
            - vb-managed-cls
        - key: cluster.open-cluster-management.io/backup
          operator: NotIn
          values:
            - cluster-activation

```



2. multiple OR rules

ACM Restore

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Restore
metadata:
  name: restore-gh-move-clusters-step1
  namespace: open-cluster-management-backup
spec:
  cleanupBeforeRestore: None # don't clean up anything, just apply the restore
  veleroCredentialsBackupName: latest
  veleroResourcesBackupName: latest
  veleroManagedClustersBackupName: skip
  orLabelSelectors: 
    - matchExpressions:
        - values:
            - vb-managed-cls
          key: name
          operator: In
    - matchExpressions:
        - values:
            - cls1-ns
          key: name
          operator: In
```

Velero restore :

```
  orLabelSelectors:
    - matchExpressions:
        - key: name
          operator: In
          values:
            - vb-managed-cls
        - key: cluster.open-cluster-management.io/backup
          operator: NotIn
          values:
            - cluster-activation
    - matchExpressions:
        - key: name
          operator: In
          values:
            - cls1-ns
        - key: cluster.open-cluster-management.io/backup
          operator: NotIn
          values:
            - cluster-activation
  scheduleName: acm-credentials-schedule
```

3. using label selector

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Restore
metadata:
  name: restore-gh-move-clusters-step5
  namespace: open-cluster-management-backup
spec:
  cleanupBeforeRestore: None # don't clean up anything, just apply the restore
  veleroCredentialsBackupName: latest
  veleroResourcesBackupName: latest
  veleroManagedClustersBackupName: skip
  labelSelector:  
    matchExpressions:
      - values:
          - vb-managed-cls
        key: name
        operator: In
      - values:
          - cls1-ns
        key: name
        operator: In
```

Restore spec ( appends cluster activation expression for generic resources )


```
  labelSelector:
    matchExpressions:
      - key: name
        operator: In
        values:
          - vb-managed-cls
      - key: name
        operator: In
        values:
          - cls1-ns
      - key: cluster.open-cluster-management.io/backup
        operator: NotIn
        values:
          - cluster-activation
```