### PR TITLE
check velero restore PartiallyFailed (https://issues.redhat.com/browse/ACM-13693)

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -234,7 +234,9 @@ func setRestorePhase(
 			)
 			return restore.Status.Phase, cleanupOnEnabled
 		}
-		if veleroRestore.Status.Phase == veleroapi.RestorePhasePartiallyFailed {
+		if strings.Contains(string(veleroRestore.Status.Phase), string(veleroapi.RestorePhasePartiallyFailed)) {
+			// check if restore status contains the PartiallyFailed string to catch
+			// all variations such as FinalizingPartiallyFailed
 			partiallyFailed = true
 			continue
 		}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-13693

Issue 
The velero restore status could return a FinalizingPartiallyFailed status for a restore that would eventually get into a PartiallyFailed status
The code only checks for the PartiallyFailed status so when the velero restore was FinalizingPartiallyFailed, acm restore returned success

Fix
Updated the code to check if the velero status contains the FailedStatus string 
