### PR TITLE
get local cluster namespace using ManagedCluster annotation (https://issues.redhat.com/browse/ACM-14425)

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -154,10 +154,6 @@ func setResourcesBackupInfo(
 ) {
 	var clusterResource bool = true
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
-	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
-		veleroBackupTemplate.ExcludedNamespaces,
-		"local-cluster",
-	)
 
 	// exclude backup chart NS
 	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
@@ -291,11 +287,6 @@ func setManagedClustersBackupInfo(
 ) {
 	var clusterResource bool = true // include cluster level resources
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
-
-	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
-		veleroBackupTemplate.ExcludedNamespaces,
-		"local-cluster",
-	)
 
 	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
 		veleroBackupTemplate.ExcludedNamespaces,

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -545,6 +545,13 @@ var _ = Describe("BackupSchedule controller", func() {
 					})
 				}
 			}
+			localClusterName := ""
+			Eventually(func() bool {
+				localCls, err := getLocalClusterName(ctx, k8sClient)
+				localClusterName = localCls
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
 			Eventually(func() error {
 				for i := range managedSvcAccountMCAOs {
 					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedSvcAccountMCAOs[i]),
@@ -652,6 +659,10 @@ var _ = Describe("BackupSchedule controller", func() {
 				if veleroSchedulesList.Items[i].Name == veleroScheduleNames[Resources] {
 					Expect(findValue(veleroSchedulesList.Items[i].Spec.Template.IncludedResources,
 						"clusterpool.other.hive.openshift.io")).Should(BeFalse())
+					// expect to find the local cluster ns in the ExcludedNamespaces list
+					Expect(findValue(veleroSchedulesList.Items[i].Spec.Template.ExcludedNamespaces,
+						localClusterName)).Should(BeTrue())
+
 				}
 				if veleroSchedulesList.Items[i].Name == veleroScheduleNames[ManagedClusters] {
 					Expect(findValue(veleroSchedulesList.Items[i].Spec.Template.IncludedResources,


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-14425

Fixed the ExcludedNamespace backup template to use the custom name of the local cluster
The local cluster is identified by the local-cluster annotation