### PR TITLE
Envtest ctrlgen updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ VERSION ?= 0.0.1
 # Helper software versions
 GOLANGCI_VERSION := v1.60.3
 CONTROLLER_TOOLS_VERSION := v0.16.1
-ENVTEST_K8S_VERSION = 1.30
+#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -145,7 +148,7 @@ $(GOLANGCILINT): $(LOCALBIN)
 ENVTEST = $(LOCALBIN)/setup-envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 
 # go-get-tool will 'go get' any package $2 and install it to $1.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION ?= 0.0.1
 
 # Helper software versions
 GOLANGCI_VERSION := v1.60.3
-CONTROLLER_TOOLS_VERSION := v0.16.1
+CONTROLLER_TOOLS_VERSION := v0.17.3
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)


### PR DESCRIPTION
Updates to Makefile:

- use controller-gen (from controller-tools) v0.17.3
- envtest - pull version to use from go.mod as well as the k8s version to use - avoids us having to update the Makefile to keep these versions in sync with the api versions we use in our code.