### PR TITLE
Golangci lint update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 ---
+version: "2"
 linters:
   # Defaults are still enabled, see:
   #  https://golangci-lint.run/usage/linters/#enabled-by-default
@@ -6,23 +7,31 @@ linters:
   # Enable these specific additional linters to match what
   # sonar checks for
   enable:
-    - goimports
-    - ineffassign
-    - misspell
-    - lll
-    - unparam
     - funlen
-
-linters-settings:
-  funlen:
-    #  Checks the number of lines in a function.
-    #  If lower than 0, disable the check.
-    #  Default: 60
-    # lines: 60
-    #  Checks the number of statements in a function.
-    #  If lower than 0, disable the check.
-    #  Default: 40
-    statements: -1
-    #  Ignore comments when counting lines.
-    #  Default false
-    ignore-comments: true
+    - lll
+    - misspell
+    - unparam
+  settings:
+    funlen:
+      statements: -1
+      ignore-comments: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 VERSION ?= 0.0.1
 
 # Helper software versions
-GOLANGCI_VERSION := v1.60.3
+GOLANGCI_VERSION := v2.0.2
 CONTROLLER_TOOLS_VERSION := v0.17.3
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -152,7 +152,7 @@ func setResourcesBackupInfo(
 	backupNS string,
 	c client.Client,
 ) {
-	var clusterResource bool = true
+	var clusterResource = true
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
 	// exclude backup chart NS
@@ -211,7 +211,7 @@ func setGenericResourcesBackupInfo(
 	resourcesToBackup []string,
 ) {
 
-	var clusterResource bool = true // check global resources
+	var clusterResource = true // check global resources
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
 	veleroBackupTemplate.ExcludedResources = getResourcesByBackupType(
@@ -239,7 +239,7 @@ func setGenericResourcesBackupInfo(
 func setCredsBackupInfo(
 	veleroBackupTemplate *veleroapi.BackupSpec,
 ) {
-	var clusterResource bool = false
+	var clusterResource = false
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
 	for i := range backupCredsResources { // secrets and configmaps
@@ -285,7 +285,7 @@ func setManagedClustersBackupInfo(
 	veleroBackupTemplate *veleroapi.BackupSpec,
 	resourcesToBackup []string,
 ) {
-	var clusterResource bool = true // include cluster level resources
+	var clusterResource = true // include cluster level resources
 	veleroBackupTemplate.IncludeClusterResources = &clusterResource
 
 	veleroBackupTemplate.ExcludedNamespaces = appendUnique(
@@ -413,7 +413,7 @@ func getResourcesByBackupType(
 
 func isBackupFinished(backups []*veleroapi.Backup) bool {
 
-	if backups == nil || len(backups) <= 0 {
+	if len(backups) <= 0 {
 		return false
 	}
 
@@ -558,7 +558,7 @@ func cleanupExpiredValidationBackups(
 		for i := range veleroBackupList.Items {
 			backup := veleroBackupList.Items[i]
 			if backup.Status.Expiration != nil &&
-				v1.Now().Time.After(backup.Status.Expiration.Time) {
+				v1.Now().After(backup.Status.Expiration.Time) {
 				backupLogger.Info(fmt.Sprintf("validation backup %s expired, attempt to delete it",
 					backup.Name))
 				if err = deleteBackup(ctx, &backup, c); err == nil {
@@ -578,8 +578,8 @@ func deleteBackup(
 ) error {
 	// delete backup now
 	backupLogger := log.FromContext(ctx)
-	backupName := backup.ObjectMeta.Name
-	backupNamespace := backup.ObjectMeta.Namespace
+	backupName := backup.Name
+	backupNamespace := backup.Namespace
 	backupLogger.Info(fmt.Sprintf("delete backup %s", backupName))
 
 	backupDeleteIdentity := types.NamespacedName{

--- a/controllers/backup_test.go
+++ b/controllers/backup_test.go
@@ -38,11 +38,11 @@ func RandStringBytesMask(n int) string {
 
 var _ = Describe("Backup", func() {
 	var (
-		backupName                      string = "the-backup-name"
-		veleroNamespaceName                    = "velero"
-		veleroManagedClustersBackupName        = "acm-managed-clusters-schedule-20210910181336"
-		veleroResourcesBackupName              = "acm-resources-schedule-20210910181336"
-		veleroCredentialsBackupName            = "acm-credentials-schedule-20210910181336"
+		backupName                      = "the-backup-name"
+		veleroNamespaceName             = "velero"
+		veleroManagedClustersBackupName = "acm-managed-clusters-schedule-20210910181336"
+		veleroResourcesBackupName       = "acm-resources-schedule-20210910181336"
+		veleroCredentialsBackupName     = "acm-credentials-schedule-20210910181336"
 
 		labelsCls123 = map[string]string{
 			"velero.io/schedule-name":  "acm-resources-schedule",

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -26,7 +26,6 @@ import (
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -612,7 +611,7 @@ func retrieveRestoreDetails(
 	restoreKeys := make([]ResourceType, 0, restoreLength)
 	for key := range veleroBackupNames {
 		if key == ValidationSchedule ||
-			(restoreOnlyManagedClusters && !(key == ManagedClusters || key == ResourcesGeneric || key == Credentials)) {
+			(restoreOnlyManagedClusters && key != ManagedClusters && key != ResourcesGeneric && key != Credentials) {
 			// ignore validation backup; this is used for the policy
 			// to validate that there are backups schedules enabled
 			// also ignore all but managed clusters when only this is restored
@@ -754,7 +753,7 @@ func setOptionalProperties(
 ) {
 	// set includeClusterResources for all restores except credentials
 	if key == Resources || key == ManagedClusters || key == ResourcesGeneric {
-		var clusterResource bool = true
+		var clusterResource = true
 		veleroRestore.Spec.IncludeClusterResources = &clusterResource
 	}
 
@@ -800,7 +799,7 @@ func setUserRestoreFilters(
 	}
 
 	if len(acmRestore.Spec.OrLabelSelectors) > 0 {
-		veleroRestore.Spec.OrLabelSelectors = make([]*v1.LabelSelector, 0, len(acmRestore.Spec.OrLabelSelectors))
+		veleroRestore.Spec.OrLabelSelectors = make([]*metav1.LabelSelector, 0, len(acmRestore.Spec.OrLabelSelectors))
 		for i := range acmRestore.Spec.OrLabelSelectors {
 			// make a copy of the label selector
 			veleroRestore.Spec.OrLabelSelectors = append(veleroRestore.Spec.OrLabelSelectors,

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -506,9 +505,9 @@ func invokeDynamicDelete(
 			return err
 		}
 
-		listOptions := v1.ListOptions{}
+		listOptions := metav1.ListOptions{}
 		if labelSelector != "" {
-			listOptions = v1.ListOptions{LabelSelector: labelSelector}
+			listOptions = metav1.ListOptions{LabelSelector: labelSelector}
 		}
 		if dynamiclist, err := dr.List(ctx, listOptions); err == nil {
 			// get all items and delete them
@@ -789,7 +788,7 @@ func deleteDynamicResource(
 				logger.Info(nsScopedPatchMsg)
 				// delete finalizers and delete resource in this way
 				if _, err := dr.Namespace(resource.GetNamespace()).Patch(ctx, resource.GetName(),
-					types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
+					types.JSONPatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
 					errMsg = err.Error()
 				}
 			}
@@ -804,7 +803,7 @@ func deleteDynamicResource(
 				// delete finalizers and delete resource in this way
 				logger.Info(globalResourcePatchMsg)
 				if _, err := dr.Patch(ctx, resource.GetName(),
-					types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
+					types.JSONPatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
 					errMsg = err.Error()
 				}
 			}

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -32,7 +32,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -119,8 +118,8 @@ func Test_postRestoreActivation(t *testing.T) {
 					*createManagedCluster("test1", false).object,
 					*createManagedCluster("managed1", false).clusterUrl("someurl").
 						conditions([]metav1.Condition{
-							v1.Condition{
-								Status: v1.ConditionTrue,
+							metav1.Condition{
+								Status: metav1.ConditionTrue,
 								Type:   "ManagedClusterConditionAvailable",
 							},
 						}).object,
@@ -153,8 +152,8 @@ func Test_postRestoreActivation(t *testing.T) {
 					*createManagedCluster("test1", false).object,
 					*createManagedCluster("managed1", false).emptyClusterUrl().
 						conditions([]metav1.Condition{
-							v1.Condition{
-								Status: v1.ConditionFalse,
+							metav1.Condition{
+								Status: metav1.ConditionFalse,
 							},
 						}).object,
 				},
@@ -200,15 +199,15 @@ func Test_postRestoreActivation(t *testing.T) {
 					*createManagedCluster("managed1", false).
 						clusterUrl("someurl").
 						conditions([]metav1.Condition{
-							v1.Condition{
-								Status: v1.ConditionFalse,
+							metav1.Condition{
+								Status: metav1.ConditionFalse,
 							},
 						}).
 						object,
 					*createManagedCluster("managed2", false).clusterUrl("someurl").
 						conditions([]metav1.Condition{
-							v1.Condition{
-								Status: v1.ConditionFalse,
+							metav1.Condition{
+								Status: metav1.ConditionFalse,
 							},
 						}).
 						object,
@@ -513,19 +512,20 @@ func Test_deleteDynamicResource(t *testing.T) {
 	resInterface := dynClient.Resource(targetGVR)
 
 	// create resources which should be found
-	_, err = resInterface.Namespace("default").Create(context.Background(), res_default, v1.CreateOptions{})
+	_, err = resInterface.Namespace("default").Create(context.Background(), res_default, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
-	_, err = resInterface.Namespace("default").Create(context.Background(), res_default_with_finalizer, v1.CreateOptions{})
+	_, err = resInterface.Namespace("default").Create(context.Background(),
+		res_default_with_finalizer, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
-	_, err = resInterface.Create(context.Background(), res_global, v1.CreateOptions{})
+	_, err = resInterface.Create(context.Background(), res_global, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
-	_, err = resInterface.Create(context.Background(), res_global_with_finalizer, v1.CreateOptions{})
+	_, err = resInterface.Create(context.Background(), res_global_with_finalizer, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
@@ -541,7 +541,7 @@ func Test_deleteDynamicResource(t *testing.T) {
 		dr                      dynamic.NamespaceableResourceInterface
 		resource                unstructured.Unstructured
 		localClusterName        string
-		deleteOptions           v1.DeleteOptions
+		deleteOptions           metav1.DeleteOptions
 		excludedNamespaces      []string
 		skipExcludedBackupLabel bool
 	}
@@ -1261,7 +1261,7 @@ func Test_deleteSecretsForBackupType(t *testing.T) {
 	ns1 := *createNamespace(namespace)
 
 	timeNow, _ := time.Parse(time.RFC3339, "2022-07-26T15:25:34Z")
-	rightNow := v1.NewTime(timeNow)
+	rightNow := metav1.NewTime(timeNow)
 	tenHourAgo := rightNow.Add(-10 * time.Hour)
 	aFewSecondsAgo := rightNow.Add(-2 * time.Second)
 
@@ -1403,7 +1403,7 @@ func Test_deleteSecretsForBackupType(t *testing.T) {
 					BackupScheduleNameLabel: "acm-credentials-hive-schedule-" + tenHourAgoTime,
 				}).
 				phase(veleroapi.BackupPhaseCompleted).
-				startTimestamp(v1.NewTime(tenHourAgo)).
+				startTimestamp(metav1.NewTime(tenHourAgo)).
 				object
 
 			err := k8sClient1.Create(ctx, &hiveOldBackup)
@@ -1419,7 +1419,7 @@ func Test_deleteSecretsForBackupType(t *testing.T) {
 					BackupScheduleNameLabel: "acm-credentials-hive-schedule-" + aFewSecondsAgoTime,
 				}).
 				phase(veleroapi.BackupPhaseCompleted).
-				startTimestamp(v1.NewTime(aFewSecondsAgo)).
+				startTimestamp(metav1.NewTime(aFewSecondsAgo)).
 				object
 
 			err := k8sClient1.Create(ctx, &hiveCloseToCredsBackup)
@@ -1623,7 +1623,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 	namespaceName := "open-cluster-management-backup"
 	timeNow, _ := time.Parse(time.RFC3339, "2022-07-26T15:25:34Z")
-	rightNow := v1.NewTime(timeNow)
+	rightNow := metav1.NewTime(timeNow)
 	tenHourAgo := rightNow.Add(-10 * time.Hour)
 	aFewSecondsAgo := rightNow.Add(-2 * time.Second)
 
@@ -1668,7 +1668,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 	genericBackup := *createBackup(veleroGenericBackupName, namespaceName).
 		excludedResources(backupManagedClusterResources).
-		startTimestamp(v1.NewTime(aFewSecondsAgo)).
+		startTimestamp(metav1.NewTime(aFewSecondsAgo)).
 		labels(map[string]string{
 			BackupScheduleTypeLabel: string(ResourcesGeneric),
 		}).
@@ -1677,7 +1677,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 	genericBackupOld := *createBackup(veleroGenericBackupNameOlder, namespaceName).
 		excludedResources(backupManagedClusterResources).
-		startTimestamp(v1.NewTime(tenHourAgo)).
+		startTimestamp(metav1.NewTime(tenHourAgo)).
 		labels(map[string]string{
 			BackupScheduleTypeLabel: string(ResourcesGeneric),
 		}).
@@ -1686,7 +1686,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 	clustersBackup := *createBackup(veleroClustersBackupName, namespaceName).
 		includedResources(backupManagedClusterResources).
 		excludedNamespaces([]string{"local-cluster"}).
-		startTimestamp(v1.NewTime(aFewSecondsAgo)).
+		startTimestamp(metav1.NewTime(aFewSecondsAgo)).
 		labels(map[string]string{
 			BackupScheduleTypeLabel: string(ManagedClusters),
 		}).
@@ -1696,7 +1696,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 	clustersBackupOld := *createBackup(veleroClustersBackupNameOlder, namespaceName).
 		includedResources(backupManagedClusterResources).
 		excludedNamespaces([]string{"local-cluster"}).
-		startTimestamp(v1.NewTime(tenHourAgo)).
+		startTimestamp(metav1.NewTime(tenHourAgo)).
 		labels(map[string]string{
 			BackupScheduleTypeLabel: string(ManagedClusters),
 		}).
@@ -2369,56 +2369,56 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 	// create some channel resources
 	_, err = dyn.Resource(chGVKList).Namespace("default").Create(context.Background(),
-		channel_with_backup_label_same, v1.CreateOptions{})
+		channel_with_backup_label_same, metav1.CreateOptions{})
 	if client.IgnoreAlreadyExists(err) != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(chGVKList).Namespace("default").Create(context.Background(),
-		channel_with_backup_label_diff, v1.CreateOptions{})
+		channel_with_backup_label_diff, metav1.CreateOptions{})
 	if client.IgnoreAlreadyExists(err) != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(chGVKList).Namespace("local-cluster").Create(context.Background(),
-		channel_with_backup_label_diff_excl_ns, v1.CreateOptions{})
+		channel_with_backup_label_diff_excl_ns, metav1.CreateOptions{})
 	if client.IgnoreAlreadyExists(err) != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(chGVKList).Namespace("default").Create(context.Background(),
-		channel_with_backup_label_generic, v1.CreateOptions{})
+		channel_with_backup_label_generic, metav1.CreateOptions{})
 	if client.IgnoreAlreadyExists(err) != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(chGVKList).Namespace("default").Create(context.Background(),
-		channel_with_no_backup_label, v1.CreateOptions{})
+		channel_with_no_backup_label, metav1.CreateOptions{})
 	if client.IgnoreAlreadyExists(err) != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 
 	// create some cluster resources
 	_, err = dyn.Resource(clsGVKList).Namespace("default").Create(context.Background(),
-		cls_with_backup_label_diff, v1.CreateOptions{})
+		cls_with_backup_label_diff, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(clsGVKList).Namespace("default").Create(context.Background(),
-		cls_with_backup_label_same, v1.CreateOptions{})
+		cls_with_backup_label_same, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(clsGVKList).Namespace("local-cluster").Create(context.Background(),
-		cls_with_backup_label_diff_excl_ns, v1.CreateOptions{})
+		cls_with_backup_label_diff_excl_ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 	_, err = dyn.Resource(clsGVKList).Namespace("default").Create(context.Background(),
-		cls_with_no_backup_label, v1.CreateOptions{})
+		cls_with_no_backup_label, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
 
 	//
 	_, err = dyn.Resource(msaGVRList).Namespace("managed1").Create(context.Background(),
-		msaObj, v1.CreateOptions{})
+		msaObj, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating: %s", err.Error())
 	}
@@ -2732,7 +2732,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 		// create resources for this test
 		for i := range tt.resourcesToCreate {
 			if _, err := dyn.Resource(chGVKList).Namespace(tt.resourcesToCreate[i].GetNamespace()).Create(context.Background(),
-				&tt.resourcesToCreate[i], v1.CreateOptions{}); err != nil {
+				&tt.resourcesToCreate[i], metav1.CreateOptions{}); err != nil {
 				t.Errorf("cannot create resource %s ", err.Error())
 			}
 		}
@@ -2754,7 +2754,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 		for i := range tt.resourcesToBeDeleted {
 			if _, err := dr.Namespace(tt.resourcesToBeDeleted[i].GetNamespace()).
-				Get(tt.args.ctx, tt.resourcesToBeDeleted[i].GetName(), v1.GetOptions{}); err == nil {
+				Get(tt.args.ctx, tt.resourcesToBeDeleted[i].GetName(), metav1.GetOptions{}); err == nil {
 				t.Errorf("cleanupDeltaForResourcesBackup(%s) resource %s should NOT be found",
 					tt.name, tt.resourcesToBeDeleted[i])
 			}
@@ -2762,7 +2762,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 		for i := range tt.resourcesToKeep {
 			if _, err := dr.Namespace(tt.resourcesToKeep[i].GetNamespace()).
-				Get(tt.args.ctx, tt.resourcesToKeep[i].GetName(), v1.GetOptions{}); err != nil {
+				Get(tt.args.ctx, tt.resourcesToKeep[i].GetName(), metav1.GetOptions{}); err != nil {
 				t.Errorf("cleanupDeltaForResourcesBackup(%s) resource %s should be found ! they were deleted",
 					tt.name, tt.resourcesToKeep[i].GetName())
 			}
@@ -2785,7 +2785,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 		// create resources for this test
 		for i := range tt.resourcesToCreate {
 			if _, err := dyn.Resource(chGVKList).Namespace(tt.resourcesToCreate[i].GetNamespace()).Create(context.Background(),
-				&tt.resourcesToCreate[i], v1.CreateOptions{}); err != nil {
+				&tt.resourcesToCreate[i], metav1.CreateOptions{}); err != nil {
 				t.Errorf("cannot create resource %s ", err.Error())
 			}
 		}
@@ -2808,7 +2808,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 		for i := range tt.resourcesToBeDeleted {
 			if _, err := dr.Namespace(tt.resourcesToBeDeleted[i].GetNamespace()).
-				Get(tt.args.ctx, tt.resourcesToBeDeleted[i].GetName(), v1.GetOptions{}); err == nil {
+				Get(tt.args.ctx, tt.resourcesToBeDeleted[i].GetName(), metav1.GetOptions{}); err == nil {
 				t.Errorf("cleanupDeltaForClustersBackup(%s) resource %s should NOT be found",
 					tt.name, tt.resourcesToBeDeleted[i])
 			}
@@ -2816,7 +2816,7 @@ func Test_cleanupDeltaForResourcesAndClustersBackup(t *testing.T) {
 
 		for i := range tt.resourcesToKeep {
 			if _, err := dr.Namespace(tt.resourcesToKeep[i].GetNamespace()).
-				Get(tt.args.ctx, tt.resourcesToKeep[i].GetName(), v1.GetOptions{}); err != nil {
+				Get(tt.args.ctx, tt.resourcesToKeep[i].GetName(), metav1.GetOptions{}); err != nil {
 				t.Errorf("cleanupDeltaForClustersBackup(%s) resource %s should be found ! they were deleted",
 					tt.name, tt.resourcesToKeep[i].GetName())
 			}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -27,7 +27,6 @@ import (
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -304,7 +303,7 @@ func Test_sendResults(t *testing.T) {
 			args: args{
 				restore: createACMRestore("Restore", "veleroNamespace").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 15}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(skipRestore).
@@ -358,7 +357,7 @@ func Test_setRestorePhase(t *testing.T) {
 			args: args{
 				restore: createACMRestore("Restore", "veleroNamespace").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 15}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(skipRestore).
@@ -375,7 +374,7 @@ func Test_setRestorePhase(t *testing.T) {
 			args: args{
 				restore: createACMRestore("Restore", "veleroNamespace").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 15}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(latestBackupStr).
 					veleroCredentialsBackupName(skipRestore).
@@ -392,7 +391,7 @@ func Test_setRestorePhase(t *testing.T) {
 			args: args{
 				restore: createACMRestore("Restore", "veleroNamespace").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 15}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -409,7 +408,7 @@ func Test_setRestorePhase(t *testing.T) {
 			args: args{
 				restore: createACMRestore("Restore", "veleroNamespace").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 15}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -716,7 +715,7 @@ func Test_isNewBackupAvailable(t *testing.T) {
 
 	restoreCreds := *createACMRestore(passiveStr, veleroNamespaceName).
 		syncRestoreWithNewBackups(true).
-		restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+		restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(skipRestore).
 		veleroCredentialsBackupName(latestBackup).
@@ -724,7 +723,7 @@ func Test_isNewBackupAvailable(t *testing.T) {
 
 	restoreCredSameBackup := *createACMRestore(passiveStr, veleroNamespaceName).
 		syncRestoreWithNewBackups(true).
-		restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+		restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(skipRestore).
 		veleroCredentialsBackupName(latestBackup).
@@ -1001,7 +1000,7 @@ func Test_setOptionalProperties(t *testing.T) {
 				restype: Credentials,
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName("skip").
 					veleroCredentialsBackupName(latestBackupStr).
@@ -1041,7 +1040,7 @@ func Test_retrieveRestoreDetails(t *testing.T) {
 
 	restoreCredsNoError := *createACMRestore("restore1", veleroNamespaceName).
 		syncRestoreWithNewBackups(true).
-		restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+		restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(skipRestore).
 		veleroCredentialsBackupName(skipRestore).
@@ -1049,7 +1048,7 @@ func Test_retrieveRestoreDetails(t *testing.T) {
 
 	restoreCredsInvalidBackupName := *createACMRestore("restore1", veleroNamespaceName).
 		syncRestoreWithNewBackups(true).
-		restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+		restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(latestBackupStr).
 		veleroCredentialsBackupName(skipRestore).
@@ -1148,7 +1147,7 @@ func Test_isOtherResourcesRunning(t *testing.T) {
 
 	restore := *createACMRestore(restoreName, veleroNamespaceName).
 		syncRestoreWithNewBackups(true).
-		restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+		restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(latestBackupStr).
 		veleroCredentialsBackupName(skipRestoreStr).
@@ -1156,7 +1155,7 @@ func Test_isOtherResourcesRunning(t *testing.T) {
 
 	restoreOther := *createACMRestore("other-"+restoreName, veleroNamespaceName).
 		syncRestoreWithNewBackups(true).
-		restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+		restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(latestBackupStr).
 		veleroCredentialsBackupName(skipRestoreStr).
@@ -1329,7 +1328,7 @@ func Test_updateLabelsForActiveResources(t *testing.T) {
 				restype: Credentials,
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(skipRestoreStr).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -1347,7 +1346,7 @@ func Test_updateLabelsForActiveResources(t *testing.T) {
 				restype: Credentials,
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(latestBackupStr).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -1402,7 +1401,7 @@ func Test_updateLabelsForActiveResources(t *testing.T) {
 				restype: ResourcesGeneric,
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(latestBackupStr).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -1448,7 +1447,7 @@ func Test_isPVCInitializationStep(t *testing.T) {
 			args: args{
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(skipRestoreStr).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -1481,7 +1480,7 @@ func Test_isPVCInitializationStep(t *testing.T) {
 			args: args{
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(latestBackupStr).
 					veleroCredentialsBackupName(latestBackupStr).
@@ -1501,7 +1500,7 @@ func Test_isPVCInitializationStep(t *testing.T) {
 			args: args{
 				acmRestore: createACMRestore("acm-restore", "ns").
 					syncRestoreWithNewBackups(true).
-					restoreSyncInterval(v1.Duration{Duration: time.Minute * 20}).
+					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 20}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(latestBackupStr).
 					veleroCredentialsBackupName(latestBackupStr).

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -300,10 +300,10 @@ func scheduleOwnsLatestStorageBackups(
 		var timeA int64
 		var timeB int64
 		if sliceBackups[i].Status.StartTimestamp != nil {
-			timeA = sliceBackups[i].Status.StartTimestamp.Time.Unix()
+			timeA = sliceBackups[i].Status.StartTimestamp.Unix()
 		}
 		if sliceBackups[j].Status.StartTimestamp != nil {
-			timeB = sliceBackups[j].Status.StartTimestamp.Time.Unix()
+			timeB = sliceBackups[j].Status.StartTimestamp.Unix()
 		}
 		return timeA < timeB
 	})

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -207,7 +207,7 @@ func (r *BackupScheduleReconciler) Reconcile(
 		clusterID, _ := getHubIdentification(ctx, r.Client)
 		err := r.initVeleroSchedules(ctx, mapper, backupSchedule, clusterID)
 		if err != nil {
-			msg := fmt.Errorf(FailedPhaseMsg+": %v", err)
+			msg := fmt.Errorf(FailedPhaseMsg+": %v", err) //nolint:staticcheck  // for capitalized err msg
 			scheduleLogger.Error(err, err.Error())
 			backupSchedule.Status.LastMessage = msg.Error()
 			backupSchedule.Status.Phase = v1beta1.SchedulePhaseFailed
@@ -287,7 +287,7 @@ func (r *BackupScheduleReconciler) isValidateConfiguration(
 
 	// don't create schedules if backup storage location doesn't exist or is not avaialable
 	veleroStorageLocations := &veleroapi.BackupStorageLocationList{}
-	if err := r.Client.List(ctx, veleroStorageLocations, &client.ListOptions{}); err != nil ||
+	if err := r.List(ctx, veleroStorageLocations, &client.ListOptions{}); err != nil ||
 		len(veleroStorageLocations.Items) == 0 {
 
 		msg := "velero.io.BackupStorageLocation resources not found. " +

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -60,9 +60,9 @@ var _ = Describe("BackupSchedule controller", func() {
 			"20210910181338",
 		}
 
-		backupScheduleName string = "the-backup-schedule-name"
+		backupScheduleName = "the-backup-schedule-name"
 
-		backupSchedule string = "0 */6 * * *"
+		backupSchedule = "0 */6 * * *"
 
 		timeout  = time.Second * 9
 		interval = time.Millisecond * 250
@@ -937,7 +937,8 @@ var _ = Describe("BackupSchedule controller", func() {
 
 				veleroSchedule := veleroScheduleList.Items[i]
 				// validate resources schedule content
-				if veleroSchedule.Name == "acm-resources-schedule" {
+				switch veleroSchedule.Name {
+				case "acm-resources-schedule":
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
 						"placement.cluster.open-cluster-management.io")).Should(BeTrue())
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
@@ -949,10 +950,7 @@ var _ = Describe("BackupSchedule controller", func() {
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
 						"clusterpool.other.hive.openshift.io")).Should(BeFalse())
 
-				} else
-				// generic resources, using backup label
-				if veleroSchedule.Name == "acm-resources-generic-schedule" {
-
+				case "acm-resources-generic-schedule": // generic resources, using backup label
 					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, // secrets are in the creds backup
 						"secret")).Should(BeTrue())
 
@@ -966,16 +964,12 @@ var _ = Describe("BackupSchedule controller", func() {
 					Expect(findValue(veleroSchedule.Spec.Template.ExcludedResources, // exclude this, part of mannged cluster
 						"clusterpool.other.hive.openshift.io")).Should(BeTrue())
 
-				} else
-				// generic resources, using backup label
-				if veleroSchedule.Name == "acm-managed-clusters-schedule" {
-
+				case "acm-managed-clusters-schedule": // generic resources, using backup label
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
 						"clusterdeployment.hive.openshift.io")).Should(BeTrue())
 					//.other.hive.openshift.io included here
 					Expect(findValue(veleroSchedule.Spec.Template.IncludedResources,
 						"clusterpool.other.hive.openshift.io")).Should(BeTrue())
-
 				}
 			}
 

--- a/controllers/schedule_test.go
+++ b/controllers/schedule_test.go
@@ -28,12 +28,10 @@ import (
 	"time"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
-	"github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	backupv1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -144,7 +142,7 @@ func initVeleroScheduleTypes() *veleroapi.ScheduleList {
 func Test_parseCronSchedule(t *testing.T) {
 	type args struct {
 		ctx            context.Context
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 	}
 	tests := []struct {
 		name string
@@ -183,12 +181,12 @@ func Test_parseCronSchedule(t *testing.T) {
 func Test_setSchedulePhase(t *testing.T) {
 	type args struct {
 		schedules      *veleroapi.ScheduleList
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 	}
 	tests := []struct {
 		name string
 		args args
-		want v1beta1.SchedulePhase
+		want backupv1beta1.SchedulePhase
 	}{
 		{
 			name: "nil schedule",
@@ -196,7 +194,7 @@ func Test_setSchedulePhase(t *testing.T) {
 				schedules:      nil,
 				backupSchedule: createBackupSchedule("name", "ns").schedule("no matter").object,
 			},
-			want: v1beta1.SchedulePhaseNew,
+			want: backupv1beta1.SchedulePhaseNew,
 		},
 		{
 			name: "schedule in collision",
@@ -205,10 +203,10 @@ func Test_setSchedulePhase(t *testing.T) {
 				backupSchedule: createBackupSchedule(
 					"name",
 					"ns",
-				).phase(v1beta1.SchedulePhaseBackupCollision).
+				).phase(backupv1beta1.SchedulePhaseBackupCollision).
 					object,
 			},
-			want: v1beta1.SchedulePhaseBackupCollision,
+			want: backupv1beta1.SchedulePhaseBackupCollision,
 		},
 		{
 			name: "new",
@@ -217,7 +215,7 @@ func Test_setSchedulePhase(t *testing.T) {
 					metav1.Duration{Duration: time.Second * 5}),
 				backupSchedule: createBackupSchedule("name", "ns").schedule("0 8 * * *").object,
 			},
-			want: v1beta1.SchedulePhaseNew,
+			want: backupv1beta1.SchedulePhaseNew,
 		},
 		{
 			name: "failed validation",
@@ -229,7 +227,7 @@ func Test_setSchedulePhase(t *testing.T) {
 				),
 				backupSchedule: createBackupSchedule("name", "ns").schedule("0 8 * * *").object,
 			},
-			want: v1beta1.SchedulePhaseFailedValidation,
+			want: backupv1beta1.SchedulePhaseFailedValidation,
 		},
 		{
 			name: "enabled",
@@ -238,7 +236,7 @@ func Test_setSchedulePhase(t *testing.T) {
 					metav1.Duration{Duration: time.Second * 5}),
 				backupSchedule: createBackupSchedule("name", "ns").schedule("0 8 * * *").object,
 			},
-			want: v1beta1.SchedulePhaseEnabled,
+			want: backupv1beta1.SchedulePhaseEnabled,
 		},
 	}
 	for _, tt := range tests {
@@ -369,7 +367,7 @@ func Test_getSchedulesWithUpdatedResources(t *testing.T) {
 func Test_isScheduleSpecUpdated(t *testing.T) {
 	type args struct {
 		schedules      *veleroapi.ScheduleList
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 	}
 	tests := []struct {
 		name string
@@ -493,7 +491,7 @@ func Test_deleteVeleroSchedules(t *testing.T) {
 	type argsDelete struct {
 		ctx            context.Context
 		c              client.Client
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 		schedules      *veleroapi.ScheduleList
 	}
 
@@ -575,7 +573,7 @@ func Test_deleteVeleroSchedules(t *testing.T) {
 	type argsUpdate struct {
 		ctx               context.Context
 		c                 client.Client
-		backupSchedule    *v1beta1.BackupSchedule
+		backupSchedule    *backupv1beta1.BackupSchedule
 		schedules         *veleroapi.ScheduleList
 		resourcesToBackup []string
 	}
@@ -761,7 +759,7 @@ func Test_isRestoreRunning(t *testing.T) {
 
 	latestRestore := "latest"
 	rhacmRestore := *createACMRestore("restore-name", veleroNamespaceName).
-		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
+		cleanupBeforeRestore(backupv1beta1.CleanupTypeRestored).
 		veleroManagedClustersBackupName(latestRestore).
 		veleroCredentialsBackupName(latestRestore).
 		veleroResourcesBackupName(latestRestore).object
@@ -769,7 +767,7 @@ func Test_isRestoreRunning(t *testing.T) {
 	type args struct {
 		ctx            context.Context
 		c              client.Client
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 	}
 	tests := []struct {
 		name string
@@ -889,7 +887,7 @@ func Test_createInitialBackupForSchedule(t *testing.T) {
 	type args struct {
 		ctx            context.Context
 		c              client.Client
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 		veleroSchedule *veleroapi.Schedule
 	}
 	tests := []struct {
@@ -987,7 +985,7 @@ func Test_createFailedValidationResponse(t *testing.T) {
 	type args struct {
 		ctx            context.Context
 		c              client.Client
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 		msg            string
 		requeue        bool
 	}
@@ -1157,7 +1155,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 		schedule("0 */6 * * *").object
 
 	// create resources which should be found
-	_, err = resInterface.Namespace("default").Create(context.Background(), res_local_ns, v1.CreateOptions{})
+	_, err = resInterface.Namespace("default").Create(context.Background(), res_local_ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating resource: %s", err.Error())
 	}
@@ -1171,7 +1169,7 @@ func Test_verifyMSAOptione(t *testing.T) {
 	type args struct {
 		ctx            context.Context
 		c              client.Client
-		backupSchedule *v1beta1.BackupSchedule
+		backupSchedule *backupv1beta1.BackupSchedule
 		mapper         *restmapper.DeferredDiscoveryRESTMapper
 	}
 	tests := []struct {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -31,7 +31,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -200,7 +199,7 @@ func processGenericCRDFromAPIGroups(
 	ctx context.Context,
 	dc discovery.DiscoveryInterface,
 	veleroBackup *veleroapi.Backup,
-	groupList v1.APIGroupList,
+	groupList metav1.APIGroupList,
 ) []string {
 	logger := log.FromContext(ctx)
 
@@ -343,7 +342,7 @@ func managedClusterShouldReimport(
 		isManagedClusterAvailable := false
 		for _, condition := range managedCluster.Status.Conditions {
 			if condition.Type == "ManagedClusterConditionAvailable" &&
-				condition.Status == v1.ConditionTrue {
+				condition.Status == metav1.ConditionTrue {
 				isManagedClusterAvailable = true
 				break
 			}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -14,7 +14,6 @@ import (
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -193,7 +192,7 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "valid-storage",
 								Namespace: "default",
-								OwnerReferences: []v1.OwnerReference{
+								OwnerReferences: []metav1.OwnerReference{
 									{
 										Kind: "DataProtectionApplication",
 									},
@@ -222,7 +221,7 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "valid-storage",
 								Namespace: "default1",
-								OwnerReferences: []v1.OwnerReference{
+								OwnerReferences: []metav1.OwnerReference{
 									{
 										Kind: "DataProtectionApplication",
 									},
@@ -240,7 +239,7 @@ func Test_isValidStorageLocationDefined(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "valid-storage",
 								Namespace: "default",
-								OwnerReferences: []v1.OwnerReference{
+								OwnerReferences: []metav1.OwnerReference{
 									{
 										Kind: "DataProtectionApplication",
 									},
@@ -426,13 +425,13 @@ func Test_managedClusterShouldReimport(t *testing.T) {
 		*createManagedCluster("test1", false).object,
 	}
 
-	conditionTypeAvailableTrue := v1.Condition{
+	conditionTypeAvailableTrue := metav1.Condition{
 		Type:   "ManagedClusterConditionAvailable",
-		Status: v1.ConditionTrue,
+		Status: metav1.ConditionTrue,
 	}
 
-	conditionTypeAvailableFalse := v1.Condition{
-		Status: v1.ConditionFalse,
+	conditionTypeAvailableFalse := metav1.Condition{
+		Status: metav1.ConditionFalse,
 		Type:   "ManagedClusterConditionAvailable",
 	}
 
@@ -736,7 +735,7 @@ func Test_VeleroCRDsPresent(t *testing.T) {
 	})
 }
 
-func labelSelectorArrayEqual(a []*v1.LabelSelector, b []v1.LabelSelector) bool {
+func labelSelectorArrayEqual(a []*metav1.LabelSelector, b []metav1.LabelSelector) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -748,7 +747,7 @@ func labelSelectorArrayEqual(a []*v1.LabelSelector, b []v1.LabelSelector) bool {
 	return true
 }
 
-func labelSelectorEqual(a *v1.LabelSelector, b *v1.LabelSelector) bool {
+func labelSelectorEqual(a *metav1.LabelSelector, b *metav1.LabelSelector) bool {
 	if a == nil && b == nil {
 		return true
 	}
@@ -805,7 +804,7 @@ func Test_addRestoreLabelSelector(t *testing.T) {
 		labelSelector metav1.LabelSelectorRequirement
 	}
 
-	emptyLabelSelector := make([]v1.LabelSelector, 0)
+	emptyLabelSelector := make([]metav1.LabelSelector, 0)
 
 	clusterActivationReq := metav1.LabelSelectorRequirement{}
 	clusterActivationReq.Key = backupCredsClusterLabel
@@ -831,8 +830,8 @@ func Test_addRestoreLabelSelector(t *testing.T) {
 	tests := []struct {
 		name                string
 		args                args
-		wantOrLabelSelector []v1.LabelSelector
-		wantLabelSelector   v1.LabelSelector
+		wantOrLabelSelector []metav1.LabelSelector
+		wantLabelSelector   metav1.LabelSelector
 	}{
 		{
 			name: "no user defined orLabelSelector or LabelSelector, get empty match expressions",
@@ -842,7 +841,7 @@ func Test_addRestoreLabelSelector(t *testing.T) {
 				labelSelector: metav1.LabelSelectorRequirement{},
 			},
 			wantOrLabelSelector: emptyLabelSelector,
-			wantLabelSelector:   v1.LabelSelector{},
+			wantLabelSelector:   metav1.LabelSelector{},
 		},
 		{
 			name: "no user defined orLabelSelector or LabelSelector, just create cluster activation LabelSelector",
@@ -893,7 +892,7 @@ func Test_addRestoreLabelSelector(t *testing.T) {
 					},
 				},
 			},
-			wantLabelSelector: v1.LabelSelector{},
+			wantLabelSelector: metav1.LabelSelector{},
 		},
 		{
 			name: "using user defined orLabelSelector, no cluster activation LabelSelector",
@@ -928,7 +927,7 @@ func Test_addRestoreLabelSelector(t *testing.T) {
 					},
 				},
 			},
-			wantLabelSelector: v1.LabelSelector{},
+			wantLabelSelector: metav1.LabelSelector{},
 		},
 		{
 			name: "using user defined LabelSelector, set cluster activation LabelSelectors as usual",


### PR DESCRIPTION
- Update to use golangci-lint v2 (v2.0.2 to be exact)
- migrate the .golangci.yml
- fix new linting issues picked up by the linter