### PR TITLE
add delete finalizer for restore

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -316,6 +316,16 @@ func (b *RestoreHelper) phase(phase veleroapi.RestorePhase) *RestoreHelper {
 	return b
 }
 
+func (b *RestoreHelper) setFinalizer(values []string) *RestoreHelper {
+	b.object.SetFinalizers(values)
+	return b
+}
+
+func (b *RestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *RestoreHelper {
+	b.object.SetDeletionTimestamp(&deletionTimestamp)
+	return b
+}
+
 // acm restore
 type ACMRestoreHelper struct {
 	object *v1beta1.Restore


### PR DESCRIPTION
Changes: add a finalizer `restores.cluster.open-cluster-management.io/finalizer` to acmRestore resources to allow cleaning up velero restores when this resource is deleted
When the acm restore is deleted, the resource gets all velero restores and deletes them if not already marked for deletion , then removes the velero finalizer so the resources can be cleaned up. Once all velere resources are cleaned up, the acm restore resources removes its finalizer and it is deleted 

https://issues.redhat.com/browse/ACM-10273