### PR TITLE
 finalizers for restore

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -446,6 +446,15 @@ func (b *ACMRestoreHelper) namespaceMapping(nspaces map[string]string) *ACMResto
 	b.object.Spec.NamespaceMapping = nspaces
 	return b
 }
+func (b *ACMRestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *ACMRestoreHelper {
+	b.object.SetDeletionTimestamp(&deletionTimestamp)
+	return b
+}
+
+func (b *ACMRestoreHelper) setFinalizer(values []string) *ACMRestoreHelper {
+	b.object.SetFinalizers(values)
+	return b
+}
 
 // backup schedule
 type BackupScheduleHelper struct {

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -446,15 +446,6 @@ func (b *ACMRestoreHelper) namespaceMapping(nspaces map[string]string) *ACMResto
 	b.object.Spec.NamespaceMapping = nspaces
 	return b
 }
-func (b *ACMRestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *ACMRestoreHelper {
-	b.object.SetDeletionTimestamp(&deletionTimestamp)
-	return b
-}
-
-func (b *ACMRestoreHelper) setFinalizer(values []string) *ACMRestoreHelper {
-	b.object.SetFinalizers(values)
-	return b
-}
 
 // backup schedule
 type BackupScheduleHelper struct {

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -316,6 +316,16 @@ func (b *RestoreHelper) phase(phase veleroapi.RestorePhase) *RestoreHelper {
 	return b
 }
 
+func (b *RestoreHelper) setFinalizer(values []string) *RestoreHelper {
+	b.object.SetFinalizers(values)
+	return b
+}
+
+func (b *RestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *RestoreHelper {
+	b.object.SetDeletionTimestamp(&deletionTimestamp)
+	return b
+}
+
 // acm restore
 type ACMRestoreHelper struct {
 	object *v1beta1.Restore

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -26,6 +27,7 @@ import (
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -892,30 +894,15 @@ func finalizeRestore(
 	return nil
 }
 
-// when the restore if first created add finalizer for the acm restore resource
-// add the same finalizer to the backup InternalHubComponent
-// if the InternalHubComponent is deleted, remove all restore resources
-// and remove the InternalHubComponent finalizer
-func processRestoreFinalizer(
+// return the internalhubcomponent with the cluster-backup name
+func getInternalHubResource(
 	ctx context.Context,
-	c client.Client,
-	acmRestore *v1beta1.Restore,
 	dyn dynamic.Interface,
 	disc discovery.DiscoveryInterface,
-) error {
-
-	if !controllerutil.AddFinalizer(acmRestore, acmRestoreFinalizer) {
-		//nothing to do, finalizer already exists
-		return nil
-	}
-
-	if acmRestore.GetDeletionTimestamp() != nil {
-		//nothing to do, resource is set to be deleted or finalizer already exists
-		return nil
-	}
+) (unstructured.Unstructured, dynamic.NamespaceableResourceInterface, error) {
 
 	reqLogger := log.FromContext(ctx)
-	reqLogger.Info("add Restore finalizer " + acmRestore.GetName())
+	reqLogger.Info("get cluster-backup  internalhubcomponent")
 
 	// Add finalizer to the backup InternalHubComponent
 	groupKind := schema.GroupKind{
@@ -927,34 +914,124 @@ func processRestoreFinalizer(
 	if err != nil {
 		reqLogger.Info(fmt.Sprintf("Failed to get dynamic mapper for group=%s, error : %s",
 			groupKind, err.Error()))
-		return err
+		return unstructured.Unstructured{}, nil, err
 	}
 
 	if dr := dyn.Resource(mapping.Resource); dr != nil {
 
 		dynamiclist, err := dr.List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return err
+			return unstructured.Unstructured{}, dr, err
 		}
 		for i := range dynamiclist.Items {
 			item := dynamiclist.Items[i]
 
 			if item.GetName() == "cluster-backup" {
-				// add restore finalizer
-				item.SetFinalizers([]string{acmRestoreFinalizer})
-				//save resource
-				_, err = dr.Namespace(item.GetNamespace()).Update(ctx, &item, metav1.UpdateOptions{})
-				if err != nil {
-					return err
-				}
+				return item, dr, nil
 			}
 		}
 	}
 
-	// Add finalizer for this CR
+	return unstructured.Unstructured{}, nil, fmt.Errorf("internalhubcomponent for cluster-backup not found")
+}
+
+// remove the acm finalizer and
+// remove internalhubcomponent finalizer if this is the only restore resource found
+func removeResourcesFinalizer(
+	ctx context.Context,
+	c client.Client,
+	dyn dynamic.Interface,
+	disc discovery.DiscoveryInterface,
+	acmRestore *v1beta1.Restore,
+) error {
+
+	reqLogger := log.FromContext(ctx)
+
+	// Remove restore finalizer. Once all finalizers have been
+	// removed, the object will be deleted.
+	controllerutil.RemoveFinalizer(acmRestore, acmRestoreFinalizer)
+
+	// if no other restore resources, remove mch finalizer
+	acmRestoreList := v1beta1.RestoreList{}
+	if err := c.List(
+		ctx,
+		&acmRestoreList,
+		client.InNamespace(acmRestore.GetNamespace())); err == nil &&
+		len(acmRestoreList.Items) == 1 {
+
+		// remove InternalHubResource restore finalizer if this is the last resource to be deleted
+		internalHubResource, dr, err := getInternalHubResource(ctx, dyn, disc)
+		if err == nil && dr != nil {
+
+			if fins := internalHubResource.GetFinalizers(); fins != nil && findValue(fins, acmRestoreFinalizer) {
+				fins = remove(fins, acmRestoreFinalizer)
+				internalHubResource.SetFinalizers(fins)
+				//save internal hub resource
+				_, err := dr.Namespace(internalHubResource.GetNamespace()).Update(ctx,
+					&internalHubResource, metav1.UpdateOptions{})
+				if err != nil {
+					// ignore error
+					reqLogger.Info(err.Error())
+				}
+
+			}
+		}
+	}
+
 	if err := c.Update(ctx, acmRestore); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// add the acm finalizer for the restore resource
+// and if needed for the internalhubcomponent
+func addResourcesFinalizer(
+	ctx context.Context,
+	c client.Client,
+	dyn dynamic.Interface,
+	disc discovery.DiscoveryInterface,
+	acmRestore *v1beta1.Restore,
+) error {
+
+	reqLogger := log.FromContext(ctx)
+	if acmRestore.DeletionTimestamp != nil {
+		// already deleted, exit
+		return nil
+	}
+
+	if controllerutil.AddFinalizer(acmRestore, acmRestoreFinalizer) {
+		// add the finalizer for the internalhubcomponent
+		internalHubResource, dr, err := getInternalHubResource(ctx, dyn, disc)
+		if err == nil {
+			if internalHubResource.GetDeletionTimestamp() == nil {
+				needsUpdate := false
+				resFins := internalHubResource.GetFinalizers()
+				if resFins == nil {
+					internalHubResource.SetFinalizers([]string{acmRestoreFinalizer})
+					needsUpdate = true
+				} else {
+					if !slices.Contains(resFins, acmRestoreFinalizer) {
+						resFins = append(resFins, acmRestoreFinalizer)
+						internalHubResource.SetFinalizers(resFins)
+						needsUpdate = true
+					}
+				}
+				if needsUpdate {
+					//save internal hub resource
+					reqLogger.Info("add finalizer for " + internalHubResource.GetName())
+					if _, err := dr.Namespace(internalHubResource.GetNamespace()).Update(ctx,
+						&internalHubResource, metav1.UpdateOptions{}); err != nil {
+						reqLogger.Info(err.Error())
+					}
+				}
+			}
+		}
+
+		// save the change for acm resource
+		return c.Update(ctx, acmRestore)
+	}
+	return nil
+
 }

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -26,7 +26,6 @@ import (
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -901,7 +900,8 @@ func processRestoreFinalizer(
 	ctx context.Context,
 	c client.Client,
 	acmRestore *v1beta1.Restore,
-	internalHubResource unstructured.Unstructured,
+	dyn dynamic.Interface,
+	disc discovery.DiscoveryInterface,
 ) error {
 
 	if !controllerutil.AddFinalizer(acmRestore, acmRestoreFinalizer) {
@@ -928,10 +928,6 @@ func processRestoreFinalizer(
 		reqLogger.Info(fmt.Sprintf("Failed to get dynamic mapper for group=%s, error : %s",
 			groupKind, err.Error()))
 		return err
-	}
-
-	if internalHubResource.GetName() == "cluster-backup" {
-
 	}
 
 	if dr := dyn.Resource(mapping.Resource); dr != nil {

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -265,12 +265,10 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	err = r.Client.Status().Update(ctx, restore)
-
-	if !isMarkedToBeDeleted && controllerutil.AddFinalizer(restore, acmRestoreFinalizer) {
-		// Add finalizer for this CR
-		if err := r.Update(ctx, restore); err != nil {
-			return ctrl.Result{}, err
-		}
+	if err == nil {
+		err = processRestoreFinalizer(ctx, r.Client, restore,
+			r.DynamicClient,
+			r.DiscoveryClient)
 	}
 
 	return sendResult(restore, err)

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -445,7 +445,6 @@ func mapFuncTriggerFinalizers(ctx context.Context, k8sClient client.Client,
 			return []reconcile.Request{}
 		}
 
-		reqs := []reconcile.Request{}
 		for i := range rsList.Items {
 			rs := rsList.Items[i]
 			reqs = append(reqs, reconcile.Request{

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -2,9 +2,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
-	"path/filepath"
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,16 +11,10 @@ import (
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/record"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -1406,185 +1397,3 @@ var _ = Describe("Basic Restore controller", func() {
 		)
 	})
 })
-
-//nolint:funlen
-func TestRestoreReconciler_finalizeRestore(t *testing.T) {
-
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "config", "crd", "bases"),
-			filepath.Join("..", "hack", "crds"),
-		},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	ns1 := *createNamespace("backup-ns")
-	acmRestore1 := *createACMRestore("acm-restore", "backup-ns").
-		cleanupBeforeRestore(v1beta1.CleanupTypeNone).syncRestoreWithNewBackups(true).
-		veleroManagedClustersBackupName(latestBackupStr).
-		veleroCredentialsBackupName(latestBackupStr).
-		veleroResourcesBackupName(latestBackupStr).object
-
-	veleroRestoreFinalizer := *createRestore("velero-res", ns1.Name).
-		backupName("backup").
-		setFinalizer([]string{restoreFinalizer}).
-		object
-	veleroRestoreFinalizerDel := *createRestore("velero-res-terminate", ns1.Name).
-		backupName("backup").
-		setFinalizer([]string{restoreFinalizer}).
-		setDeleteTimestamp(metav1.NewTime(time.Now())).
-		object
-
-	scheme1 := runtime.NewScheme()
-	e1 := corev1.AddToScheme(scheme1)
-	e2 := veleroapi.AddToScheme(scheme1)
-	e3 := v1beta1.AddToScheme(scheme1)
-	if err := errors.Join(e1, e2, e3); err != nil {
-		t.Fatalf("Error adding apis to scheme: %s", err.Error())
-	}
-
-	cfg, err := testEnv.Start()
-	if err != nil {
-		t.Fatalf("Error starting testEnv: %s", err.Error())
-	}
-	k8sClient1, err := client.New(cfg, client.Options{Scheme: scheme1})
-	if err != nil {
-		t.Fatalf("Error starting client: %s", err.Error())
-	}
-	errs := []error{}
-	errs = append(errs, k8sClient1.Create(context.Background(), &ns1))
-	errs = append(errs, k8sClient1.Create(context.Background(), &acmRestore1))
-	errs = append(errs, k8sClient1.Create(context.Background(), &veleroRestoreFinalizer))
-	errs = append(errs, k8sClient1.Create(context.Background(), &veleroRestoreFinalizerDel))
-	if err := errors.Join(errs...); err != nil {
-		t.Fatalf("Error creating objects for test setup: %s", err.Error())
-	}
-
-	type fields struct {
-		Client          client.Client
-		KubeClient      kubernetes.Interface
-		DiscoveryClient discovery.DiscoveryInterface
-		DynamicClient   dynamic.Interface
-		Scheme          *runtime.Scheme
-		Recorder        record.EventRecorder
-	}
-	type args struct {
-		ctx               context.Context
-		c                 client.Client
-		acmRestore        *v1beta1.Restore
-		veleroRestoreList veleroapi.RestoreList
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name: "no restores, return nil",
-			args: args{
-				ctx:               context.Background(),
-				c:                 k8sClient1,
-				acmRestore:        &acmRestore1,
-				veleroRestoreList: veleroapi.RestoreList{},
-			},
-			wantErr: false,
-			errMsg:  "",
-		},
-		{
-			name: "has velero restores, but not marked for deletion, finalizer should NOT be removed",
-			args: args{
-				ctx:        context.Background(),
-				c:          k8sClient1,
-				acmRestore: &acmRestore1,
-				veleroRestoreList: veleroapi.RestoreList{
-					Items: []veleroapi.Restore{
-						veleroRestoreFinalizer,
-					},
-				},
-			},
-			wantErr: true,
-			errMsg:  "waiting for velero restores to be terminated",
-		},
-		{
-			name: "has velero restores, marked for deletion, but resource not found",
-			args: args{
-				ctx:        context.Background(),
-				c:          k8sClient1,
-				acmRestore: &acmRestore1,
-				veleroRestoreList: veleroapi.RestoreList{
-					Items: []veleroapi.Restore{
-						*createRestore("velero-1", ns1.Name).
-							backupName("backup").
-							setFinalizer([]string{restoreFinalizer}).
-							setDeleteTimestamp(metav1.NewTime(time.Now())).
-							object,
-					},
-				},
-			},
-			wantErr: true,
-			errMsg:  `restores.velero.io "velero-1" not found`,
-		},
-		{
-			name: "has velero restores, not marked for deletion and resource not found, delete must fail",
-			args: args{
-				ctx:        context.Background(),
-				c:          k8sClient1,
-				acmRestore: &acmRestore1,
-				veleroRestoreList: veleroapi.RestoreList{
-					Items: []veleroapi.Restore{
-						*createRestore("velero-1", ns1.Name).
-							backupName("backup").
-							setFinalizer([]string{restoreFinalizer}).
-							object,
-					},
-				},
-			},
-			wantErr: true,
-			errMsg:  `restores.velero.io "velero-1" not found`,
-		},
-		{
-			name: "has velero restores, marked for deletion, finalizer should be removed",
-			args: args{
-				ctx:        context.Background(),
-				c:          k8sClient1,
-				acmRestore: &acmRestore1,
-				veleroRestoreList: veleroapi.RestoreList{
-					Items: []veleroapi.Restore{
-						veleroRestoreFinalizerDel,
-					},
-				},
-			},
-			wantErr: true,
-			errMsg:  "waiting for velero restores to be terminated",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			err := finalizeRestore(tt.args.ctx, tt.args.c, tt.args.acmRestore, tt.args.veleroRestoreList)
-
-			if err != nil && err.Error() != tt.errMsg {
-				t.Errorf("got an error but not the one expected error = %v, wantErr %v", err.Error(), tt.errMsg)
-			}
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("RestoreReconciler.finalizeRestore() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			for _, veleroRestore := range tt.args.veleroRestoreList.Items {
-				if controllerutil.ContainsFinalizer(&veleroRestore, restoreFinalizer) &&
-					veleroRestore.GetDeletionTimestamp() != nil &&
-					veleroRestore.Name != "velero-1" {
-					t.Errorf("Velero restore marked for deletion but finalizer not removed name=%v",
-						veleroRestore.Name)
-
-				}
-			}
-		})
-	}
-	if err := testEnv.Stop(); err != nil {
-		t.Fatalf("Error stopping testenv: %s", err.Error())
-	}
-}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -35,9 +35,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Test_isVeleroRestoreFinished(t *testing.T) {
@@ -1610,6 +1612,8 @@ func Test_isPVCInitializationStep(t *testing.T) {
 }
 
 func Test_processRestoreWait(t *testing.T) {
+
+	logf.SetLogger(klog.NewKlogr())
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
@@ -1774,6 +1778,7 @@ func hasActivationLabel(
 }
 
 func Test_actLabelNotOnManagedClsRestore(t *testing.T) {
+	logf.SetLogger(klog.NewKlogr())
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
@@ -1949,7 +1954,7 @@ func Test_actLabelNotOnManagedClsRestore(t *testing.T) {
 
 //nolint:funlen
 func TestRestoreReconciler_finalizeRestore(t *testing.T) {
-
+	logf.SetLogger(klog.NewKlogr())
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -29,8 +30,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
@@ -1936,6 +1942,188 @@ func Test_actLabelNotOnManagedClsRestore(t *testing.T) {
 		}
 	}
 	// clean up
+	if err := testEnv.Stop(); err != nil {
+		t.Fatalf("Error stopping testenv: %s", err.Error())
+	}
+}
+
+//nolint:funlen
+func TestRestoreReconciler_finalizeRestore(t *testing.T) {
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join("..", "hack", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	ns1 := *createNamespace("backup-ns")
+	acmRestore1 := *createACMRestore("acm-restore", "backup-ns").
+		cleanupBeforeRestore(v1beta1.CleanupTypeNone).syncRestoreWithNewBackups(true).
+		veleroManagedClustersBackupName(latestBackupStr).
+		veleroCredentialsBackupName(latestBackupStr).
+		veleroResourcesBackupName(latestBackupStr).object
+
+	veleroRestoreFinalizer := *createRestore("velero-res", ns1.Name).
+		backupName("backup").
+		setFinalizer([]string{restoreFinalizer}).
+		object
+	veleroRestoreFinalizerDel := *createRestore("velero-res-terminate", ns1.Name).
+		backupName("backup").
+		setFinalizer([]string{restoreFinalizer}).
+		setDeleteTimestamp(metav1.NewTime(time.Now())).
+		object
+
+	scheme1 := runtime.NewScheme()
+	e1 := corev1.AddToScheme(scheme1)
+	e2 := veleroapi.AddToScheme(scheme1)
+	e3 := v1beta1.AddToScheme(scheme1)
+	if err := errors.Join(e1, e2, e3); err != nil {
+		t.Fatalf("Error adding apis to scheme: %s", err.Error())
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("Error starting testEnv: %s", err.Error())
+	}
+	k8sClient1, err := client.New(cfg, client.Options{Scheme: scheme1})
+	if err != nil {
+		t.Fatalf("Error starting client: %s", err.Error())
+	}
+	errs := []error{}
+	errs = append(errs, k8sClient1.Create(context.Background(), &ns1))
+	errs = append(errs, k8sClient1.Create(context.Background(), &acmRestore1))
+	errs = append(errs, k8sClient1.Create(context.Background(), &veleroRestoreFinalizer))
+	errs = append(errs, k8sClient1.Create(context.Background(), &veleroRestoreFinalizerDel))
+	if err := errors.Join(errs...); err != nil {
+		t.Fatalf("Error creating objects for test setup: %s", err.Error())
+	}
+
+	type fields struct {
+		Client          client.Client
+		KubeClient      kubernetes.Interface
+		DiscoveryClient discovery.DiscoveryInterface
+		DynamicClient   dynamic.Interface
+		Scheme          *runtime.Scheme
+		Recorder        record.EventRecorder
+	}
+	type args struct {
+		ctx               context.Context
+		c                 client.Client
+		acmRestore        *v1beta1.Restore
+		veleroRestoreList veleroapi.RestoreList
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "no restores, return nil",
+			args: args{
+				ctx:               context.Background(),
+				c:                 k8sClient1,
+				acmRestore:        &acmRestore1,
+				veleroRestoreList: veleroapi.RestoreList{},
+			},
+			wantErr: false,
+			errMsg:  "",
+		},
+		{
+			name: "has velero restores, but not marked for deletion, finalizer should NOT be removed",
+			args: args{
+				ctx:        context.Background(),
+				c:          k8sClient1,
+				acmRestore: &acmRestore1,
+				veleroRestoreList: veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						veleroRestoreFinalizer,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "waiting for velero restores to be terminated",
+		},
+		{
+			name: "has velero restores, marked for deletion, but resource not found",
+			args: args{
+				ctx:        context.Background(),
+				c:          k8sClient1,
+				acmRestore: &acmRestore1,
+				veleroRestoreList: veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						*createRestore("velero-1", ns1.Name).
+							backupName("backup").
+							setFinalizer([]string{restoreFinalizer}).
+							setDeleteTimestamp(metav1.NewTime(time.Now())).
+							object,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  `restores.velero.io "velero-1" not found`,
+		},
+		{
+			name: "has velero restores, not marked for deletion and resource not found, delete must fail",
+			args: args{
+				ctx:        context.Background(),
+				c:          k8sClient1,
+				acmRestore: &acmRestore1,
+				veleroRestoreList: veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						*createRestore("velero-1", ns1.Name).
+							backupName("backup").
+							setFinalizer([]string{restoreFinalizer}).
+							object,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  `restores.velero.io "velero-1" not found`,
+		},
+		{
+			name: "has velero restores, marked for deletion, finalizer should be removed",
+			args: args{
+				ctx:        context.Background(),
+				c:          k8sClient1,
+				acmRestore: &acmRestore1,
+				veleroRestoreList: veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						veleroRestoreFinalizerDel,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "waiting for velero restores to be terminated",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := finalizeRestore(tt.args.ctx, tt.args.c, tt.args.acmRestore, tt.args.veleroRestoreList)
+
+			if err != nil && err.Error() != tt.errMsg {
+				t.Errorf("got an error but not the one expected error = %v, wantErr %v", err.Error(), tt.errMsg)
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RestoreReconciler.finalizeRestore() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			for _, veleroRestore := range tt.args.veleroRestoreList.Items {
+				if controllerutil.ContainsFinalizer(&veleroRestore, restoreFinalizer) &&
+					veleroRestore.GetDeletionTimestamp() != nil &&
+					veleroRestore.Name != "velero-1" {
+					t.Errorf("Velero restore marked for deletion but finalizer not removed name=%v",
+						veleroRestore.Name)
+
+				}
+			}
+		})
+	}
 	if err := testEnv.Stop(); err != nil {
 		t.Fatalf("Error stopping testenv: %s", err.Error())
 	}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -30,8 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -2006,12 +2004,10 @@ func TestRestoreReconciler_finalizeRestore(t *testing.T) {
 	}
 
 	type fields struct {
-		Client          client.Client
-		KubeClient      kubernetes.Interface
-		DiscoveryClient discovery.DiscoveryInterface
-		DynamicClient   dynamic.Interface
-		Scheme          *runtime.Scheme
-		Recorder        record.EventRecorder
+		Client     client.Client
+		KubeClient kubernetes.Interface
+		Scheme     *runtime.Scheme
+		Recorder   record.EventRecorder
 	}
 	type args struct {
 		ctx               context.Context

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -149,7 +149,7 @@ func Test_isValidSyncOptions(t *testing.T) {
 		{
 			name: "Skip all",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).syncRestoreWithNewBackups(true).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(skipRestore).
@@ -160,7 +160,7 @@ func Test_isValidSyncOptions(t *testing.T) {
 		{
 			name: "No backup name",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).syncRestoreWithNewBackups(true).object,
 			},
 			want: false,
@@ -168,7 +168,7 @@ func Test_isValidSyncOptions(t *testing.T) {
 		{
 			name: "Credentials should be set to skip or latest",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeAll).syncRestoreWithNewBackups(true).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(backupName).
@@ -179,7 +179,7 @@ func Test_isValidSyncOptions(t *testing.T) {
 		{
 			name: "Resources should be set to latest",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).syncRestoreWithNewBackups(true).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(latestBackup).
@@ -190,7 +190,7 @@ func Test_isValidSyncOptions(t *testing.T) {
 		{
 			name: "InValid config, no sync",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(latestBackup).
@@ -201,7 +201,7 @@ func Test_isValidSyncOptions(t *testing.T) {
 		{
 			name: "Valid config",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(skipRestore).
@@ -234,7 +234,7 @@ func Test_isSkipAllRestores(t *testing.T) {
 		{
 			name: "Skip all",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(skipRestore).
@@ -245,7 +245,7 @@ func Test_isSkipAllRestores(t *testing.T) {
 		{
 			name: "No backup name",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					object,
 			},
 			want: true,
@@ -253,7 +253,7 @@ func Test_isSkipAllRestores(t *testing.T) {
 		{
 			name: "Do not skip all",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(latestBackup).
@@ -264,7 +264,7 @@ func Test_isSkipAllRestores(t *testing.T) {
 		{
 			name: "Managed clusters name is not skip",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
 					veleroManagedClustersBackupName(latestBackup).
 					veleroCredentialsBackupName(latestBackup).
@@ -275,7 +275,7 @@ func Test_isSkipAllRestores(t *testing.T) {
 		{
 			name: "Resources is not skip",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
 					veleroCredentialsBackupName(skipRestore).
@@ -307,7 +307,7 @@ func Test_sendResults(t *testing.T) {
 		{
 			name: "Try restore again",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
@@ -323,7 +323,7 @@ func Test_sendResults(t *testing.T) {
 		{
 			name: "Skip restore again",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
 					veleroManagedClustersBackupName(skipRestore).
@@ -361,7 +361,7 @@ func Test_setRestorePhase(t *testing.T) {
 		{
 			name: "Restore list empty and skip all, return finished phase",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
@@ -378,7 +378,7 @@ func Test_setRestorePhase(t *testing.T) {
 		{
 			name: "Restore list empty and NOT skip all, return finished RestorePhaseStarted",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
@@ -395,7 +395,7 @@ func Test_setRestorePhase(t *testing.T) {
 		{
 			name: "Restore phase is RestorePhaseEnabled and sync option, return wantCleanupOnEnabled is false",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
@@ -412,7 +412,7 @@ func Test_setRestorePhase(t *testing.T) {
 		{
 			name: "Restore list empty and NOT skip all, return finished RestorePhaseEnabled and wantCleanupOnEnabled is TRUE",
 			args: args{
-				restore: createACMRestore("Restore", "veleroNamespace").
+				restore: createACMRestore("Restore", "velero-ns").
 					syncRestoreWithNewBackups(true).
 					restoreSyncInterval(metav1.Duration{Duration: time.Minute * 15}).
 					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
@@ -430,7 +430,7 @@ func Test_setRestorePhase(t *testing.T) {
 							},
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "restore",
-								Namespace: "veleroNamespace",
+								Namespace: "velero-ns",
 							},
 							Spec: veleroapi.RestoreSpec{
 								BackupName: "backup",
@@ -1135,6 +1135,9 @@ func Test_retrieveRestoreDetails(t *testing.T) {
 				t.Errorf("Error stopping testenv: %s", err.Error())
 			}
 		}
+	}
+	if err := testEnv.Stop(); err != nil {
+		t.Fatalf("Error stopping testenv: %s", err.Error())
 	}
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -553,9 +553,9 @@ var _ = BeforeSuite(func() {
 	})
 
 	mchGVK := schema.GroupVersionKind{Group: "operator.open-cluster-management.io",
-		Version: "v1beta1", Kind: "InternalHubComponent"}
+		Version: "v1", Kind: "InternalHubComponent"}
 	mchGVRList := schema.GroupVersionResource{Group: "operator.open-cluster-management.io",
-		Version: "v1beta1", Resource: "internalhubcomponents"}
+		Version: "v1", Resource: "internalhubcomponents"}
 
 	msaGVK := schema.GroupVersionKind{Group: "authentication.open-cluster-management.io",
 		Version: "v1beta1", Kind: "ManagedServiceAccount"}
@@ -708,7 +708,7 @@ var _ = BeforeSuite(func() {
 
 	dynR := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(unstructuredSchemeR,
 		gvrToListKindR,
-		msaObj, msaObj2, clsvObj, res_channel_default, clsHiveObj)
+		mchObj, msaObj, msaObj2, clsvObj, res_channel_default, clsHiveObj)
 
 	//create some resources
 	/* These creates all come back with an "already exists" error - are they being faked out

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -82,6 +82,15 @@ func appendUnique(slice []string, value string) []string {
 	return slice
 }
 
+func remove(s []string, r string) []string {
+	for i, v := range s {
+		if v == r {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}
+
 // min returns the smallest of x or y.
 func min(x, y int) int {
 	if x < y {

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1386,5 +1387,41 @@ func Test_updateBackupSchedulePhaseWhenPaused(t *testing.T) {
 	// clean up
 	if err := testEnv.Stop(); err != nil {
 		t.Fatalf("Error stopping testenv: %s", err.Error())
+	}
+}
+
+func Test_remove(t *testing.T) {
+	type args struct {
+		s []string
+		r string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "string now found",
+			args: args{
+				s: []string{"b", "c"},
+				r: "a",
+			},
+			want: []string{"b", "c"},
+		},
+		{
+			name: "string found and removed",
+			args: args{
+				s: []string{"b", "c", "a", "d"},
+				r: "a",
+			},
+			want: []string{"b", "c", "d"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remove(tt.args.s, tt.args.r); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("remove() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/hack/crds/operator.open-cluster-management.io_internalhubcomponents.yaml
+++ b/hack/crds/operator.open-cluster-management.io_internalhubcomponents.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: internalhubcomponents.operator.open-cluster-management.io
+spec:
+  group: operator.open-cluster-management.io
+  names:
+    kind: InternalHubComponent
+    listKind: InternalHubComponentList
+    plural: internalhubcomponents
+    singular: internalhubcomponent
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10273
Issue : when the backup operator is disabled on MCH, all resources, including backup ns are deleted. The velero Restores have finalizers so if there are any acm Restore resources ( which own those resources ) , the ns is stuck in Terminating 

Fix: 
Try to watch the InternalHubComponent.operator.open-cluster-management.io resource and on delete action (named cluster-backup ), clean up all resources. This is defined by the stolostron multiclusterhub project https://github.com/stolostron/multiclusterhub-operator
Steps:
- add a watch for the InternalHubComponent.operator.open-cluster-management.io  ( unstructured resource  )
1. This watches on delete action. When this happens, it should delete all acm restores - tbd
- update the acm restore reconcile : 
1. on acm resource creation add the estores.cluster.open-cluster-management.io/finalizer finalizer
2. add the same finalizer to the InternalHubComponent ( cluster-backup ) resource so it waits when deleted
3. if the acm resource has a deletion timestamp, delete all Restore resources ( wait for that ); when all are deleted, remove the  acm resource finalizer. If this is the last acm Resource, also delete the  InternalHubComponent ( cluster-backup )  finalizer. 