### PR TITLE
add restore finalizer

### DIFF
--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -316,6 +316,16 @@ func (b *RestoreHelper) phase(phase veleroapi.RestorePhase) *RestoreHelper {
 	return b
 }
 
+func (b *RestoreHelper) setFinalizer(values []string) *RestoreHelper {
+	b.object.SetFinalizers(values)
+	return b
+}
+
+func (b *RestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *RestoreHelper {
+	b.object.SetDeletionTimestamp(&deletionTimestamp)
+	return b
+}
+
 // acm restore
 type ACMRestoreHelper struct {
 	object *v1beta1.Restore

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
@@ -17,6 +18,19 @@ const (
 	acmApiVersion    = "cluster.open-cluster-management.io/v1beta1"
 	veleroApiVersion = "velero.io/v1"
 )
+
+func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+		},
+	}
+}
 
 func createNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -346,6 +346,16 @@ func createACMRestore(name string, ns string) *ACMRestoreHelper {
 	}
 }
 
+func (b *ACMRestoreHelper) setFinalizer(values []string) *ACMRestoreHelper {
+	b.object.SetFinalizers(values)
+	return b
+}
+
+func (b *ACMRestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *ACMRestoreHelper {
+	b.object.SetDeletionTimestamp(&deletionTimestamp)
+	return b
+}
+
 func (b *ACMRestoreHelper) cleanupBeforeRestore(cleanup v1beta1.CleanupType) *ACMRestoreHelper {
 	b.object.Spec.CleanupBeforeRestore = cleanup
 	return b

--- a/controllers/create_helper.go
+++ b/controllers/create_helper.go
@@ -330,11 +330,6 @@ func (b *RestoreHelper) phase(phase veleroapi.RestorePhase) *RestoreHelper {
 	return b
 }
 
-func (b *RestoreHelper) setFinalizer(values []string) *RestoreHelper {
-	b.object.SetFinalizers(values)
-	return b
-}
-
 func (b *RestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *RestoreHelper {
 	b.object.SetDeletionTimestamp(&deletionTimestamp)
 	return b
@@ -362,11 +357,6 @@ func createACMRestore(name string, ns string) *ACMRestoreHelper {
 
 func (b *ACMRestoreHelper) setFinalizer(values []string) *ACMRestoreHelper {
 	b.object.SetFinalizers(values)
-	return b
-}
-
-func (b *ACMRestoreHelper) setDeleteTimestamp(deletionTimestamp metav1.Time) *ACMRestoreHelper {
-	b.object.SetDeletionTimestamp(&deletionTimestamp)
 	return b
 }
 

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -923,8 +923,12 @@ func removeResourcesFinalizer(
 	if err := c.List(
 		ctx,
 		&acmRestoreList,
-		client.InNamespace(acmRestore.GetNamespace())); err == nil &&
-		len(acmRestoreList.Items) == 1 {
+		client.InNamespace(acmRestore.GetNamespace())); err != nil {
+		// don't continue if restore list fails
+		return err
+	}
+
+	if len(acmRestoreList.Items) == 1 {
 
 		// remove InternalHubResource restore finalizer if this is the last resource to be deleted
 		mchGVRList := schema.GroupVersionResource{

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -900,7 +900,7 @@ func getInternalHubResource(
 	reqLogger := log.FromContext(ctx)
 	reqLogger.Info("get cluster-backup  internalhubcomponent")
 
-	mchGVRList := schema.GroupVersionResource{Group: "operator.open-cluster-management.io",
+	mchGVRList := schema.GroupVersionResource{Group: ihcGroup,
 		Version: "v1", Resource: "internalhubcomponents"}
 	mchList, err := dyn.Resource(mchGVRList).Namespace("open-cluster-management").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -946,7 +946,7 @@ func removeResourcesFinalizer(
 
 		// remove InternalHubResource restore finalizer if this is the last resource to be deleted
 		mchGVRList := schema.GroupVersionResource{
-			Group:   "operator.open-cluster-management.io",
+			Group:   ihcGroup,
 			Version: "v1", Resource: "internalhubcomponents"}
 		if internalHubResource != nil {
 			if fins := internalHubResource.GetFinalizers(); fins != nil && findValue(fins, acmRestoreFinalizer) {
@@ -993,7 +993,7 @@ func addResourcesFinalizer(
 
 		// remove InternalHubResource restore finalizer if this is the last resource to be deleted
 		mchGVRList := schema.GroupVersionResource{
-			Group:   "operator.open-cluster-management.io",
+			Group:   ihcGroup,
 			Version: "v1", Resource: "internalhubcomponents"}
 		if internalHubResource != nil &&
 			internalHubResource.GetDeletionTimestamp() == nil {

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -997,9 +997,9 @@ func addResourcesFinalizer(
 			}
 		}
 
-		if acmRestore.GetDeletionTimestamp() == nil &&
-			controllerutil.AddFinalizer(acmRestore, acmRestoreFinalizer) {
-			// add finalizer if resource not deleted then update the acm resource
+		if !controllerutil.ContainsFinalizer(acmRestore, acmRestoreFinalizer) {
+			controllerutil.AddFinalizer(acmRestore, acmRestoreFinalizer)
+			// add finalizer then update the acm resource
 			return c.Update(ctx, acmRestore)
 		}
 	}

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -955,7 +955,7 @@ func removeResourcesFinalizer(
 
 	// Remove restore finalizer. Once all finalizers have been
 	// removed, the object will be deleted.
-	controllerutil.RemoveFinalizer(acmRestore, acmRestoreFinalizer)
+	needsUpdate := controllerutil.RemoveFinalizer(acmRestore, acmRestoreFinalizer)
 
 	// if no other restore resources, remove mch finalizer
 	acmRestoreList := v1beta1.RestoreList{}
@@ -967,7 +967,6 @@ func removeResourcesFinalizer(
 
 		// remove InternalHubResource restore finalizer if this is the last resource to be deleted
 		if dr != nil {
-
 			if fins := internalHubResource.GetFinalizers(); fins != nil && findValue(fins, acmRestoreFinalizer) {
 				fins = remove(fins, acmRestoreFinalizer)
 				internalHubResource.SetFinalizers(fins)
@@ -983,8 +982,10 @@ func removeResourcesFinalizer(
 		}
 	}
 
-	if err := c.Update(ctx, acmRestore); err != nil {
-		return err
+	if needsUpdate {
+		if err := c.Update(ctx, acmRestore); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -166,7 +166,7 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		restore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors {
 		// don't process a restore resource if it's completed
 		// try to add the finalizer
-		return ctrl.Result{}, addResourcesFinalizer(ctx, r.Client, r.DynamicClient, internalHubResource, restore)
+		return ctrl.Result{}, nil
 	}
 
 	// don't create restores if there is any other active resource in this namespace

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -71,6 +71,7 @@ const (
 
 	acmRestoreFinalizer = "restores.cluster.open-cluster-management.io/finalizer"
 	restoreFinalizer    = "restores.velero.io/external-resources-finalizer"
+	ihcGroup            = "operator.open-cluster-management.io"
 )
 
 type DynamicStruct struct {
@@ -414,10 +415,9 @@ func (r *RestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// watch InternalHubComponent as an unstructured resource
 	ihc := &unstructured.Unstructured{}
-
 	ihc.SetGroupVersionKind(schema.GroupVersionKind{
 		Kind:    "InternalHubComponent",
-		Group:   "operator.open-cluster-management.io",
+		Group:   ihcGroup,
 		Version: "v1",
 	})
 
@@ -429,7 +429,6 @@ func (r *RestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return mapFuncTriggerFinalizers(ctx, mgr.GetClient(), o)
 			}), builder.WithPredicates(processFinalizersPredicate())).
 		Complete(r)
-
 }
 
 // process InternalHubComponent resources and watch for a delete action

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -165,11 +165,8 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if restore.Status.Phase == v1beta1.RestorePhaseFinished ||
 		restore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors {
 		// don't process a restore resource if it's completed
-		if err := addResourcesFinalizer(ctx, r.Client, internalHubResource, dr, restore); err != nil {
-			restoreLogger.Info(fmt.Sprintf("addResourcesFinalizer: %s", err.Error()))
-		}
-
-		return ctrl.Result{}, nil
+		// just try to add the finalizer
+		return ctrl.Result{}, addResourcesFinalizer(ctx, r.Client, internalHubResource, dr, restore)
 	}
 
 	// don't create restores if there is any other active resource in this namespace

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -69,7 +69,6 @@ const (
 	pvcWaitInterval = time.Second * 10
 
 	acmRestoreFinalizer = "restores.cluster.open-cluster-management.io/finalizer"
-	restoreFinalizer    = "restores.velero.io/external-resources-finalizer"
 	ihcGroup            = "operator.open-cluster-management.io"
 )
 

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -174,13 +174,14 @@ func recordClustersRestoreOperation(
 			"namespace", veleroBackup.Namespace,
 		)
 	}
-
 	logger.Info("exit recordClustersRestoreOperation ")
 }
 
 // clean up resources with a restore label
 // but not part of the latest restore
 // these are delta resources that need to be cleaned up
+//
+//nolint:funlen
 func cleanupDeltaResources(
 	ctx context.Context,
 	c client.Client,
@@ -224,6 +225,7 @@ func cleanupDeltaResources(
 	return processed
 }
 
+//nolint:funlen
 func cleanupDeltaForCredentials(
 	ctx context.Context,
 	c client.Client,
@@ -423,6 +425,7 @@ func cleanupDeltaForClustersBackup(
 	deleteDynamicResourcesForBackup(ctx, c, restoreOptions, veleroBackup, "")
 }
 
+//nolint:funlen
 func deleteDynamicResourcesForBackup(
 	ctx context.Context,
 	c client.Client,

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -2149,31 +2149,12 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	mchObjAdd := &unstructured.Unstructured{}
-	mchObjAdd.SetUnstructuredContent(map[string]interface{}{
-		"apiVersion": "operator.open-cluster-management.io/v1",
-		"kind":       "InternalHubComponent",
-		"metadata": map[string]interface{}{
-			"name":      "cluster-backup",
-			"namespace": "ns1",
-			"spec":      map[string]interface{}{},
-		},
-	})
+	mchObjAdd := newUnstructured("operator.open-cluster-management.io/v1", "InternalHubComponent",
+		"ns1", "cluster-backup")
 
-	mchObjDel := &unstructured.Unstructured{}
-	mchObjDel.SetUnstructuredContent(map[string]interface{}{
-		"apiVersion": "operator.open-cluster-management.io/v1",
-		"kind":       "InternalHubComponent",
-		"metadata": map[string]interface{}{
-			"name":      "cluster-backup",
-			"namespace": "default",
-			"spec":      map[string]interface{}{},
-		},
-	})
+	mchObjDel := newUnstructured("operator.open-cluster-management.io/v1", "InternalHubComponent",
+		"default", "cluster-backup")
 
-	mchGVK := schema.GroupVersionKind{Group: "operator.open-cluster-management.io",
-		Version: "v1", Kind: "InternalHubComponent"}
-	mchGVR := mchGVK.GroupVersion().WithResource("internalhubcomponent")
 	mchGVRList := schema.GroupVersionResource{Group: "operator.open-cluster-management.io",
 		Version: "v1", Resource: "internalhubcomponents"}
 
@@ -2185,6 +2166,7 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme,
 		gvrToListKindR,
 	)
+	resInterface := dynClient.Resource(mchGVRList)
 
 	if _, err := dynClient.Resource(mchGVRList).Namespace("default").Create(context.Background(),
 		mchObjDel, metav1.CreateOptions{}); err != nil {
@@ -2194,8 +2176,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 		mchObjAdd, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
-
-	resInterface := dynClient.Resource(mchGVR)
 
 	ns1 := *createNamespace("backup-ns")
 	acmRestore1 := *createACMRestore("acm-restore", "backup-ns").
@@ -2383,6 +2363,7 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			}
 		})
 	}
+
 	if err := testEnv.Stop(); err != nil {
 		t.Fatalf("Error stopping testenv: %s", err.Error())
 	}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -2223,9 +2223,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	}
 	errs := []error{}
 	errs = append(errs, k8sClient1.Create(context.Background(), &ns1))
-	errs = append(errs, k8sClient1.Create(context.Background(), &acmRestore1))
-	errs = append(errs, k8sClient1.Create(context.Background(), &acmRestoreWFin))
-
 	if err := errors.Join(errs...); err != nil {
 		t.Errorf("Error creating objs to setup for test: %s", err.Error())
 	}
@@ -2277,10 +2274,15 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 
+			// create resource
+			if err := k8sClient1.Create(context.Background(), tt.args.acmRestore); err != nil {
+				t.Errorf("Error creating objs to setup for test: %s", err.Error())
+			}
 			if err := removeResourcesFinalizer(tt.args.ctx, tt.args.c,
 				tt.args.dyn, tt.args.internalHubResource, tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("removeResourcesFinalizer() error = %v, wantErr %v", err, tt.wantErr)
 			} else {
+
 				// check finalizers were added
 				if (tt.args.internalHubResource.GetFinalizers() != nil) != tt.wantMCHFinalizer {
 					t.Errorf("internalHubResource should have a finalizer wantMCHFinalizer %v", tt.wantMCHFinalizer)

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -2166,7 +2166,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme,
 		gvrToListKindR,
 	)
-	resInterface := dynClient.Resource(mchGVRList)
 
 	if _, err := dynClient.Resource(mchGVRList).Namespace("default").Create(context.Background(),
 		mchObjDel, metav1.CreateOptions{}); err != nil {
@@ -2234,8 +2233,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	type args struct {
 		ctx                 context.Context
 		c                   client.Client
-		internalHubResource unstructured.Unstructured
-		dr                  dynamic.NamespaceableResourceInterface
+		internalHubResource *unstructured.Unstructured
+		dyn                 dynamic.Interface
 		acmRestore          *v1beta1.Restore
 	}
 
@@ -2251,8 +2250,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			args: args{
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
-				internalHubResource: *mchObjDel,
-				dr:                  resInterface,
+				internalHubResource: mchObjDel,
+				dyn:                 dynClient,
 				acmRestore:          &acmRestore1,
 			},
 			wantErr:          false,
@@ -2264,8 +2263,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			args: args{
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
-				internalHubResource: *mchObjDel,
-				dr:                  resInterface,
+				internalHubResource: mchObjDel,
+				dyn:                 dynClient,
 				acmRestore:          &acmRestoreWFin,
 			},
 			wantErr:          false,
@@ -2278,8 +2277,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 
-			if err := removeResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource,
-				tt.args.dr, tt.args.acmRestore); (err != nil) != tt.wantErr {
+			if err := removeResourcesFinalizer(tt.args.ctx, tt.args.c,
+				tt.args.dyn, tt.args.internalHubResource, tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("removeResourcesFinalizer() error = %v, wantErr %v", err, tt.wantErr)
 			} else {
 				// check finalizers were added
@@ -2310,8 +2309,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			args: args{
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
-				internalHubResource: *mchObjAdd,
-				dr:                  resInterface,
+				internalHubResource: mchObjAdd,
+				dyn:                 dynClient,
 				acmRestore:          &acmRestoreWDelFin,
 			},
 			wantErr:          false,
@@ -2323,8 +2322,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			args: args{
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
-				internalHubResource: *mchObjAdd,
-				dr:                  resInterface,
+				internalHubResource: mchObjAdd,
+				dyn:                 dynClient,
 				acmRestore:          &acmRestoreWFin1,
 			},
 			wantErr:          false,
@@ -2336,8 +2335,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			args: args{
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
-				internalHubResource: *mchObjAdd,
-				dr:                  resInterface,
+				internalHubResource: mchObjAdd,
+				dyn:                 dynClient,
 				acmRestore:          &acmRestore1,
 			},
 			wantErr:          false,
@@ -2349,8 +2348,8 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	for _, tt := range add_tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := addResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource,
-				tt.args.dr, tt.args.acmRestore); (err != nil) != tt.wantErr {
+			if err := addResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.dyn, tt.args.internalHubResource,
+				tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("addResourcesFinalizer() error = %v, wantErr %v", err, tt.wantErr)
 			} else {
 				// check finalizers were added

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -28,7 +28,6 @@ import (
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -2188,11 +2187,11 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	)
 
 	if _, err := dynClient.Resource(mchGVRList).Namespace("default").Create(context.Background(),
-		mchObjDel, v1.CreateOptions{}); err != nil {
+		mchObjDel, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
 	if _, err := dynClient.Resource(mchGVRList).Namespace("ns1").Create(context.Background(),
-		mchObjAdd, v1.CreateOptions{}); err != nil {
+		mchObjAdd, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Err creating: %s", err.Error())
 	}
 

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -2291,15 +2291,16 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 
-			if err := removeResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource, tt.args.dr, tt.args.acmRestore); (err != nil) != tt.wantErr {
+			if err := removeResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource,
+				tt.args.dr, tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("removeResourcesFinalizer() error = %v, wantErr %v", err, tt.wantErr)
 			} else {
 				// check finalizers were added
 				if (tt.args.internalHubResource.GetFinalizers() != nil) != tt.wantMCHFinalizer {
-					t.Errorf("removeResourcesFinalizer() internalHubResource should have a finalizer wantMCHFinalizer %v", tt.wantMCHFinalizer)
+					t.Errorf("internalHubResource should have a finalizer wantMCHFinalizer %v", tt.wantMCHFinalizer)
 				}
 				if (tt.args.acmRestore.GetFinalizers() != nil) != tt.wantACMFinalizer {
-					t.Errorf("removeResourcesFinalizer() acmRestore should have a finalizer , wantACMFinalizer %v", tt.wantACMFinalizer)
+					t.Errorf("acmRestore should have a finalizer , wantACMFinalizer %v", tt.wantACMFinalizer)
 				}
 			}
 		})
@@ -2359,15 +2360,16 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	for _, tt := range add_tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := addResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource, tt.args.dr, tt.args.acmRestore); (err != nil) != tt.wantErr {
+			if err := addResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource,
+				tt.args.dr, tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("addResourcesFinalizer() error = %v, wantErr %v", err, tt.wantErr)
 			} else {
 				// check finalizers were added
 				if (tt.args.internalHubResource.GetFinalizers() != nil) != tt.wantMCHFinalizer {
-					t.Errorf("addResourcesFinalizer() internalHubResource should have a finalizer wantMCHFinalizer %v", tt.wantMCHFinalizer)
+					t.Errorf("internalHubResource should have a finalizer wantMCHFinalizer %v", tt.wantMCHFinalizer)
 				}
 				if (tt.args.acmRestore.GetFinalizers() != nil) != tt.wantACMFinalizer {
-					t.Errorf("addResourcesFinalizer() acmRestore should have a finalizer , wantACMFinalizer %v", tt.wantACMFinalizer)
+					t.Errorf("acmRestore should have a finalizer , wantACMFinalizer %v", tt.wantACMFinalizer)
 				}
 			}
 		})

--- a/controllers/schedule.go
+++ b/controllers/schedule.go
@@ -397,6 +397,7 @@ func isRestoreRunning(
 	return restoreName
 }
 
+//nolint:funlen
 func createInitialBackupForSchedule(
 	ctx context.Context,
 	c client.Client,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -171,6 +171,13 @@ var _ = BeforeSuite(func() {
 			{Name: "managedserviceaccounts", Namespaced: true, Kind: "ManagedServiceAccount"},
 		},
 	}
+	mchV1 := metav1.APIResourceList{
+		GroupVersion: "operator.open-cluster-management.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "internalhubcomponents", Namespaced: true, Kind: "InternalHubComponent"},
+		},
+	}
+
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var list interface{}
 		switch req.URL.Path {
@@ -188,6 +195,8 @@ var _ = BeforeSuite(func() {
 			list = &hiveInfo
 		case "/apis/authentication.open-cluster-management.io/v1beta1":
 			list = authAlpha1
+		case "/apis/operator.open-cluster-management.io/v1":
+			list = mchV1
 		case "/apis/apps.open-cluster-management.io/v1beta1":
 			list = &appsInfo
 		case "/apis/apps.open-cluster-management.io/v1":
@@ -284,6 +293,12 @@ var _ = BeforeSuite(func() {
 						},
 					},
 					{
+						Name: "operator.open-cluster-management.io",
+						Versions: []metav1.GroupVersionForDiscovery{
+							{GroupVersion: "operator.open-cluster-management.io/v1", Version: "v1"},
+						},
+					},
+					{
 						Name: "addon.open-cluster-management.io",
 						Versions: []metav1.GroupVersionForDiscovery{
 							{GroupVersion: "addon.open-cluster-management.io/v1alpha1", Version: "v1alpha1"},
@@ -323,6 +338,12 @@ var _ = BeforeSuite(func() {
 			resourcesList: &authAlpha1,
 			path:          "/apis/authentication.open-cluster-management.io/v1beta1",
 			request:       "authentication.open-cluster-management.io/v1beta1",
+			expectErr:     false,
+		},
+		{
+			resourcesList: &mchV1,
+			path:          "/apis/operator.open-cluster-management.io/v1",
+			request:       "operator.open-cluster-management.io/v1",
 			expectErr:     false,
 		},
 		{
@@ -479,6 +500,17 @@ var _ = BeforeSuite(func() {
 		},
 	})
 
+	mchObj := &unstructured.Unstructured{}
+	mchObj.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "operator.open-cluster-management.io/v1",
+		"kind":       "InternalHubComponent",
+		"metadata": map[string]interface{}{
+			"name":      "cluster-backup",
+			"namespace": "managed1",
+			"spec":      map[string]interface{}{},
+		},
+	})
+
 	msaObj := &unstructured.Unstructured{}
 	msaObj.SetUnstructuredContent(map[string]interface{}{
 		"apiVersion": "authentication.open-cluster-management.io/v1beta1",
@@ -519,6 +551,11 @@ var _ = BeforeSuite(func() {
 			},
 		},
 	})
+
+	mchGVK := schema.GroupVersionKind{Group: "operator.open-cluster-management.io",
+		Version: "v1", Kind: "InternalHubComponent"}
+	mchGVRList := schema.GroupVersionResource{Group: "operator.open-cluster-management.io",
+		Version: "v1", Resource: "internalhubcomponents"}
 
 	msaGVK := schema.GroupVersionKind{Group: "authentication.open-cluster-management.io",
 		Version: "v1beta1", Kind: "ManagedServiceAccount"}
@@ -630,6 +667,7 @@ var _ = BeforeSuite(func() {
 
 	///
 	gvrToListKindR := map[schema.GroupVersionResource]string{
+		mchGVRList:    "InternalHubComponentList",
 		msaGVRList:    "ManagedServiceAccountList",
 		clsVGVKList:   "ClusterVersionList",
 		clsDGVKList:   "ClusterDeploymentList",
@@ -649,6 +687,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	unstructuredSchemeR := runtime.NewScheme()
+	unstructuredSchemeR.AddKnownTypes(mchGVK.GroupVersion(), mchObj)
 	unstructuredSchemeR.AddKnownTypes(msaGVK.GroupVersion(), msaObj)
 	unstructuredSchemeR.AddKnownTypes(msaGVK.GroupVersion(), msaObj2)
 	unstructuredSchemeR.AddKnownTypes(clsVGVK.GroupVersion(), clsvObj)
@@ -669,7 +708,7 @@ var _ = BeforeSuite(func() {
 
 	dynR := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(unstructuredSchemeR,
 		gvrToListKindR,
-		msaObj, msaObj2, clsvObj, res_channel_default, clsHiveObj)
+		mchObj, msaObj, msaObj2, clsvObj, res_channel_default, clsHiveObj)
 
 	//create some resources
 	/* These creates all come back with an "already exists" error - are they being faked out

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -82,6 +82,15 @@ func appendUnique(slice []string, value string) []string {
 	return slice
 }
 
+func remove(s []string, r string) []string {
+	for i, v := range s {
+		if v == r {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}
+
 // min returns the smallest of x or y.
 func min(x, y int) int {
 	if x < y {

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1386,5 +1387,41 @@ func Test_updateBackupSchedulePhaseWhenPaused(t *testing.T) {
 	// clean up
 	if err := testEnv.Stop(); err != nil {
 		t.Fatalf("Error stopping testenv: %s", err.Error())
+	}
+}
+
+func Test_remove(t *testing.T) {
+	type args struct {
+		s []string
+		r string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "string now found",
+			args: args{
+				s: []string{"b", "c"},
+				r: "a",
+			},
+			want: []string{"b", "c"},
+		},
+		{
+			name: "string found and removed",
+			args: args{
+				s: []string{"b", "c", "a", "d"},
+				r: "a",
+			},
+			want: []string{"b", "c", "d"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remove(tt.args.s, tt.args.r); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("remove() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/hack/crds/operator.open-cluster-management.io_internalhubcomponents.yaml
+++ b/hack/crds/operator.open-cluster-management.io_internalhubcomponents.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: internalhubcomponents.operator.open-cluster-management.io
+spec:
+  group: operator.open-cluster-management.io
+  names:
+    kind: InternalHubComponent
+    listKind: InternalHubComponentList
+    plural: internalhubcomponents
+    singular: internalhubcomponent
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10273
Issue : when the backup operator is disabled on MCH, all resources, including backup ns are deleted. The velero Restores have finalizers so if there are any acm Restore resources ( which own those resources ) , the ns is stuck in Terminating 

Fix: 
Try to watch the InternalHubComponent.operator.open-cluster-management.io resource and on delete action (named cluster-backup ), clean up all resources. This is defined by the stolostron multiclusterhub project https://github.com/stolostron/multiclusterhub-operator
Steps:
- add a watch for the InternalHubComponent.operator.open-cluster-management.io  ( unstructured resource  )
1. This watches on delete action. When this happens, it should delete all acm restores - tbd
- update the acm restore reconcile : 
1. on acm resource creation add the estores.cluster.open-cluster-management.io/finalizer finalizer
2. add the same finalizer to the InternalHubComponent ( cluster-backup ) resource so it waits when deleted
3. if the acm resource has a deletion timestamp, delete all Restore resources ( wait for that ); when all are deleted, remove the  acm resource finalizer. If this is the last acm Resource, also delete the  InternalHubComponent ( cluster-backup )  finalizer. 