### PR TITLE
replace dynamic interface updates with client calls

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -906,7 +906,6 @@ func getInternalHubResource(
 func removeResourcesFinalizer(
 	ctx context.Context,
 	c client.Client,
-	dyn dynamic.Interface,
 	internalHubResource *unstructured.Unstructured,
 	acmRestore *v1beta1.Restore,
 ) error {
@@ -932,11 +931,7 @@ func removeResourcesFinalizer(
 		// remove finalizer
 		controllerutil.RemoveFinalizer(internalHubResource, acmRestoreFinalizer)
 		//save internal hub resource
-		mchGVRList := schema.GroupVersionResource{
-			Group:   ihcGroup,
-			Version: "v1", Resource: "internalhubcomponents"}
-		if _, err := dyn.Resource(mchGVRList).Namespace(internalHubResource.GetNamespace()).Update(ctx,
-			internalHubResource, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
+		if err := c.Update(ctx, internalHubResource); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -955,7 +950,6 @@ func removeResourcesFinalizer(
 func addResourcesFinalizer(
 	ctx context.Context,
 	c client.Client,
-	dyn dynamic.Interface,
 	internalHubResource *unstructured.Unstructured,
 	acmRestore *v1beta1.Restore,
 ) error {
@@ -973,11 +967,7 @@ func addResourcesFinalizer(
 		if needsUpdate {
 			//save internal hub resource
 			reqLogger.Info("add finalizer for " + internalHubResource.GetName())
-			mchGVRList := schema.GroupVersionResource{
-				Group:   ihcGroup,
-				Version: "v1", Resource: "internalhubcomponents"}
-			if _, err := dyn.Resource(mchGVRList).Namespace(internalHubResource.GetNamespace()).Update(ctx,
-				internalHubResource, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
+			if err := c.Update(ctx, internalHubResource); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -141,7 +141,7 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	isMarkedForDeletion := restore.GetDeletionTimestamp() != nil
 	if !isMarkedForDeletion {
-		if err := addResourcesFinalizer(ctx, r.Client, r.DynamicClient, internalHubResource, restore); err != nil {
+		if err := addResourcesFinalizer(ctx, r.Client, internalHubResource, restore); err != nil {
 			restoreLogger.Info(fmt.Sprintf("addResourcesFinalizer: %s", err.Error()))
 		}
 	} else {
@@ -155,8 +155,7 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		// Remove restore finalizer for acm restore and internalhub resource if this is the only restore
 		// Once all finalizers have been removed, the object will be deleted.
-		return ctrl.Result{}, removeResourcesFinalizer(ctx, r.Client,
-			r.DynamicClient, internalHubResource, restore)
+		return ctrl.Result{}, removeResourcesFinalizer(ctx, r.Client, internalHubResource, restore)
 	}
 	// check if internalhubcomponent is marked for deletion
 	// delete this resource if that's the case

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -2319,7 +2319,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			}
 		})
 	}
-
 	if err := testEnv.Stop(); err != nil {
 		t.Fatalf("Error stopping testenv: %s", err.Error())
 	}

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -2195,7 +2194,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 		ctx                 context.Context
 		c                   client.Client
 		internalHubResource *unstructured.Unstructured
-		dyn                 dynamic.Interface
 		acmRestore          *v1beta1.Restore
 	}
 
@@ -2213,7 +2211,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
 				internalHubResource: mchObjDel,
-				dyn:                 dynClient,
 				acmRestore:          &acmRestoreWFin,
 			},
 			wantErr:          false,
@@ -2229,7 +2226,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
 				internalHubResource: mchObjDel2,
-				dyn:                 dynClient,
 				acmRestore:          &acmRestore1,
 			},
 			wantErr:          false,
@@ -2254,7 +2250,7 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 			}
 
 			if err := removeResourcesFinalizer(tt.args.ctx, tt.args.c,
-				tt.args.dyn, tt.args.internalHubResource, tt.args.acmRestore); (err != nil) != tt.wantErr {
+				tt.args.internalHubResource, tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("removeResourcesFinalizer() error = %v, wantErr: %v", err, tt.wantErr)
 			} else {
 
@@ -2286,7 +2282,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
 				internalHubResource: mchObjAdd,
-				dyn:                 dynClient,
 				acmRestore:          &acmRestoreWFin1,
 			},
 			wantErr:          false,
@@ -2299,7 +2294,6 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 				ctx:                 context.Background(),
 				c:                   k8sClient1,
 				internalHubResource: mchObjAdd,
-				dyn:                 dynClient,
 				acmRestore:          &acmRestore1,
 			},
 			wantErr:          false,
@@ -2311,7 +2305,7 @@ func Test_addOrRemoveResourcesFinalizer(t *testing.T) {
 	for _, tt := range add_tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := addResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.dyn, tt.args.internalHubResource,
+			if err := addResourcesFinalizer(tt.args.ctx, tt.args.c, tt.args.internalHubResource,
 				tt.args.acmRestore); (err != nil) != tt.wantErr {
 				t.Errorf("addResourcesFinalizer() error = %v, wantErr %v", err, tt.wantErr)
 			} else {


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10273

related to https://github.com/stolostron/cluster-backup-operator/pull/978

Use controller client to update internalhubcomponent unstructured resource, instead of using the dynamic interface