### PR TITLE
[release-2.13] konflux - enable build-source-image

### DIFF
--- a/.tekton/cluster-backup-operator-acm-213-pull-request.yaml
+++ b/.tekton/cluster-backup-operator-acm-213-pull-request.yaml
@@ -22,6 +22,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/cluster-backup-operator-acm-213-push.yaml
+++ b/.tekton/cluster-backup-operator-acm-213-push.yaml
@@ -21,6 +21,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
- will be required for the enterprise contract, similar to hermetic builds