### PR TITLE
[Release 2.12] konflux enable build source image

### DIFF
--- a/.tekton/cluster-backup-operator-acm-212-pull-request.yaml
+++ b/.tekton/cluster-backup-operator-acm-212-pull-request.yaml
@@ -18,6 +18,12 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/cluster-backup-operator-acm-212-push.yaml
+++ b/.tekton/cluster-backup-operator-acm-212-push.yaml
@@ -17,6 +17,12 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
- will be required for the enterprise contract

Signed-off-by: Tesshu Flower <tflower@redhat.com>
(cherry picked from commit 1d85b9519398e8546a576af9a593cf149487081f)