### PR TITLE
konflux - enable build-source-image (#1003)

### DIFF
--- a/.tekton/cluster-backup-operator-acm-211-pull-request.yaml
+++ b/.tekton/cluster-backup-operator-acm-211-pull-request.yaml
@@ -18,6 +18,12 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/cluster-backup-operator-acm-211-push.yaml
+++ b/.tekton/cluster-backup-operator-acm-211-push.yaml
@@ -17,6 +17,12 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -14,15 +14,25 @@ COPY config/. config/
 COPY controllers/ controllers/
 
 # Copy the go source
-RUN  CGO_ENABLED=1 go mod vendor
-RUN  CGO_ENABLED=1 go mod tidy
+RUN  CGO_ENABLED=1 GOFLAGS='-mod=readonly' go mod vendor
+# RUN  CGO_ENABLED=1 GOFLAGS='-mod=readonly' GOOS=linux GOARCH=amd64 go mod tidy
 
 # Build
-RUN CGO_ENABLED=1 go build -tags strictfipsruntime -a -o manager main.go
+RUN CGO_ENABLED=1 GOFLAGS='-mod=readonly' go build -tags strictfipsruntime -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
+LABEL \
+    name="cluster-backup-operator" \
+    com.redhat.component="cluster-backup-operator" \
+    description="The Cluster Backup and Restore Operator runs on the hub cluster, providing disaster recovery \
+    solutions for Red Hat Advanced Cluster Management in the event of hub cluster failures." \
+    io.k8s.description="The Cluster Backup and Restore Operator runs on the hub cluster, providing disaster recovery \
+    solutions for Red Hat Advanced Cluster Management in the event of hub cluster failures." \
+    summary="An ACM operator that delivers disaster recovery solutions for hub cluster failures." \
+    io.k8s.display-name="Red Hat Advanced Cluster Management Cluster Backup and Restore Operator" \
+    io.openshift.tags="acm cluster-backup-operator"
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
- will be required for the enterprise contract, similar to hermetic builds

Signed-off-by: Tesshu Flower <tflower@redhat.com>
(cherry picked from commit 1d85b9519398e8546a576af9a593cf149487081f)