### PR TITLE
update renovate after making release-2.15 br

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "addLabels": ["ok-to-test"],
-  "baseBranches": ["/(^main$)|(^release-2\\.(10|11|12|13)$)/"],
+  "addLabels": [
+    "ok-to-test"
+  ],
+  "baseBranches": [
+    "main",
+    "release-0.10",
+    "release-0.11",
+    "release-0.12",
+    "release-0.13",
+    "release-0.14"
+  ],
   "rebaseWhen": "behind-base-branch",
   "recreateWhen": "never",
-  "schedule": ["before 8am on tuesday and thursday"],
+  "schedule": [
+    "before 8am on tuesday and thursday"
+  ],
   "timezone": "America/New_York"
 }


### PR DESCRIPTION
main will now ffwd to release-2.15 so we want
renovate/mintmaker to update main as well as past release branches (excluding release-2.15)