### PR TITLE
remove release-2.10 from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
   ],
   "baseBranches": [
     "main",
-    "release-2.10",
     "release-2.11",
     "release-2.12",
     "release-2.13",
@@ -14,7 +13,6 @@
   "packageRules": [
     {
       "baseBranchList": [
-        "release-2.10",
         "release-2.11",
         "release-2.12",
         "release-2.13",


### PR DESCRIPTION
- not building release-2.10 via konflux so remove renovate/mintmaker updates (they were there primarily to update the konflux tekton pipelines)