### PR TITLE
tekton update for clamav scan migration

### DIFF
--- a/.tekton/cluster-backup-operator-acm-214-pull-request.yaml
+++ b/.tekton/cluster-backup-operator-acm-214-pull-request.yaml
@@ -414,7 +414,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:9cab95ac9e833d77a63c079893258b73b8d5a298d93aaf9bdd6722471bc2f338
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
         - name: kind
           value: task
         resolver: bundles
@@ -423,6 +423,11 @@ spec:
         operator: in
         values:
         - "false"
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
     - name: sast-coverity-check
       params:
       - name: image-digest

--- a/.tekton/cluster-backup-operator-acm-214-push.yaml
+++ b/.tekton/cluster-backup-operator-acm-214-push.yaml
@@ -435,7 +435,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:9cab95ac9e833d77a63c079893258b73b8d5a298d93aaf9bdd6722471bc2f338
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
         - name: kind
           value: task
         resolver: bundles
@@ -444,6 +444,11 @@ spec:
         operator: in
         values:
         - "false"
+      matrix:
+        params:
+        - name: image-arch
+          value:
+          - $(params.build-platforms)
     - name: sast-coverity-check
       params:
       - name: image-digest


### PR DESCRIPTION
- update clamav scan to 0.3

- Adding matrix as per migration doc: https://github.com/konflux-ci/build-definitions/blob/main/task/clamav-scan/0.3/MIGRATION.md

  Doing the above manually as it did not get done automatically for this release branch by the pipeline-migration-tool