### PR TITLE
fix renovate cfg for gomod updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,13 +21,13 @@
       "matchManagers": [
         "gomod"
       ],
-      "enabled": false,
-      "vulnerabilityAlerts": {
-        "enabled": true
-      },
-      "osvVulnerabilityAlerts": true
+      "enabled": false
     }
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
   "rebaseWhen": "behind-base-branch",
   "prConcurrentLimit": 0,
   "timezone": "America/New_York",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,20 +10,22 @@
     "release-2.13",
     "release-2.14"
   ],
-  "packageRules": [
-    {
-      "matchBaseBranches": [
-        "release-2.11",
-        "release-2.12",
-        "release-2.13",
-        "release-2.14"
-      ],
-      "matchManagers": [
-        "gomod"
-      ],
-      "enabled": false
-    }
-  ],
+  "gomod": {
+    "packageRules": [
+      {
+        "matchBaseBranches": [
+          "release-2.11",
+          "release-2.12",
+          "release-2.13",
+          "release-2.14"
+        ],
+        "matchManagers": [
+          "gomod"
+        ],
+        "enabled": false
+      }
+    ]
+  },
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
Disabling go.mod updates (for non-security) on older release branches has not been working.

Some updates to the renovate.json as suggested in a support ticket in `konflux-users` - see thread:

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1755524348522629