### PR TITLE
fix schedule update progress intermitent failure

### DIFF
--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -1280,9 +1280,8 @@ var _ = Describe("BackupSchedule controller", func() {
 						return true, nil
 					}
 
-					// Early failure if no progress after reasonable time - indicates a real issue
-					// Instead of waiting forever, fail fast if there's clearly a problem
-					return false, fmt.Errorf("schedule update progress: %d/%d updated", updatedCount, expectedScheduleCount)
+					// Keep polling without treating partial progress as an error
+					return false, nil
 
 				}, timeout*2, interval).Should(BeTrue(), "All Velero schedules should be updated")
 


### PR DESCRIPTION
Issue : the reconciler updates Velero Schedules then returns with a requeue. The test updates the spec again immediately and expects all 5 Schedules to reflect the new cron within 20s. Under envtest with controller cache sync and background work, reconcile can lag; the function returns an error for any partial progress which keeps Eventually in “error” state until it times out.
Fix: changed the test to stop failing on partial progress. It now keeps polling until all 5 Velero Schedules reflect the new cron, without emitting an error per tick.