### PR TITLE
Fix gemini PR review from forked branches

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,7 +1,7 @@
 name: '🧐 Gemini Pull Request Review'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - 'opened'
       - 'reopened'
@@ -41,7 +41,7 @@ jobs:
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
       ) ||
       (


### PR DESCRIPTION
Added a context change for the PR target, that should allow it to correctly run on PR's from forked repositories.

Gemini-cli reviews.