### PR TITLE
disable gomod indirect updates, reorganize

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,8 +10,20 @@
     "release-2.13",
     "release-2.14"
   ],
+  "prConcurrentLimit": 0,
+  "dependencyDashboard": true,
+  "timezone": "America/New_York",
+  "dockerfile": {
+    "managerFilePatterns": ["Dockerfile.rhtap"],
+    "ignorePaths": ["**/Dockerfile"],
+    "pinDigests": true
+  },
   "gomod": {
     "packageRules": [
+      {
+        "matchDepTypes": ["indirect"],
+        "enabled": false
+      },
       {
         "matchBaseBranches": [
           "release-2.11",
@@ -26,23 +38,14 @@
       }
     ]
   },
-  "dockerfile": {
-    "managerFilePatterns": ["Dockerfile.rhtap"],
-    "ignorePaths": ["**/Dockerfile"],
-    "pinDigests": true
-  },
-  "packageRules": [
-    {
-      "groupName": "containerfile images",
-      "matchManagers": ["dockerfile"]
-    }
-  ],
   "vulnerabilityAlerts": {
     "enabled": true
   },
   "osvVulnerabilityAlerts": true,
-  "rebaseWhen": "behind-base-branch",
-  "prConcurrentLimit": 0,
-  "timezone": "America/New_York",
-  "dependencyDashboard": true
+  "packageRules": [
+    {
+      "groupName": "containerfile images ({{{baseBranch}}})",
+      "matchManagers": ["dockerfile"]
+    }
+  ]
 }


### PR DESCRIPTION
- reorder the config file a bit too to match more closely with what Dale has done https://github.com/dhaiducek/config-policy-controller/blob/ed0951c8736f084adcb0c657a7a6d29ada5dc9ff/.github/renovate.json.

Not matching the config exactly, as we still want updates to gomod for our main branch for direct dependencies.