### PR TITLE
Add url label to Dockerfile.rhtap

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -32,7 +32,8 @@ LABEL \
     solutions for Red Hat Advanced Cluster Management in the event of hub cluster failures." \
     summary="An ACM operator that delivers disaster recovery solutions for hub cluster failures." \
     io.k8s.display-name="Red Hat Advanced Cluster Management Cluster Backup and Restore Operator" \
-    io.openshift.tags="acm cluster-backup-operator"
+    io.openshift.tags="acm cluster-backup-operator" \
+    url="https://github.com/stolostron/cluster-backup-operator"
 WORKDIR /
 COPY --from=builder /workspace/manager .
 


### PR DESCRIPTION
## Summary

Add url label pointing to the GitHub repository URL in the Dockerfile.rhtap.

## Changes

- Added `url="https://github.com/stolostron/cluster-backup-operator"` label to the LABEL section in Dockerfile.rhtap

🤖 Generated with [Claude Code](https://claude.ai/code)