### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-backup-operator-acm-215

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -24,7 +24,8 @@ RUN CGO_ENABLED=1 GOFLAGS='-mod=readonly' go build -tags strictfipsruntime -a -o
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8
 LABEL \
-    name="cluster-backup-operator" \
+    name="rhacm2/cluster-backup-rhel9-operator" \
+    cpe="cpe:/a:redhat:acm:2.15::el9" \
     com.redhat.component="cluster-backup-operator" \
     description="The Cluster Backup and Restore Operator runs on the hub cluster, providing disaster recovery \
     solutions for Red Hat Advanced Cluster Management in the event of hub cluster failures." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Claude <noreply@anthropic.com>