### PR TITLE
ACM-31191: Fix reconcile return values (restore + schedule controllers)

### DIFF
--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -208,17 +208,16 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		updateRestoreStatus(restoreLogger, v1beta1.RestorePhaseError, msg, restore)
 
-		if retry {
-			// retry after failureInterval
-			return ctrl.Result{RequeueAfter: failureInterval}, errors.Wrap(
-				r.Client.Status().Update(ctx, restore),
-				msg,
-			)
+		if err := r.Client.Status().Update(ctx, restore); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, msg)
 		}
-		return ctrl.Result{}, errors.Wrap(
-			r.Client.Status().Update(ctx, restore),
-			msg,
-		)
+
+		if retry {
+			return ctrl.Result{RequeueAfter: failureInterval}, nil
+		}
+
+		return ctrl.Result{}, nil
+
 	} else if restore.Status.Phase == v1beta1.RestorePhaseEnabledError &&
 		strings.Contains(restore.Status.LastMessage, "BackupStorageLocation") {
 		// if the restore is in enabled error phase, and the storage location is available,
@@ -270,19 +269,19 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// set error status for all errors from initVeleroRestores
 			updateRestoreStatus(restoreLogger, v1beta1.RestorePhaseError, err.Error(), restore)
-			return ctrl.Result{RequeueAfter: failureInterval}, errors.Wrap(
-				r.Client.Status().Update(ctx, restore),
-				msg,
-			)
+			if updErr := r.Client.Status().Update(ctx, restore); updErr != nil {
+				return ctrl.Result{}, errors.Wrap(updErr, msg)
+			}
+			return ctrl.Result{RequeueAfter: failureInterval}, nil
 		}
 
 		if mustwait {
 			restore.Status.Phase = v1beta1.RestorePhaseStarted
 			restore.Status.LastMessage = waitmsg
-			return ctrl.Result{RequeueAfter: pvcWaitInterval}, errors.Wrap(
-				r.Client.Status().Update(ctx, restore),
-				waitmsg,
-			)
+			if updErr := r.Client.Status().Update(ctx, restore); updErr != nil {
+				return ctrl.Result{}, errors.Wrap(updErr, waitmsg)
+			}
+			return ctrl.Result{RequeueAfter: pvcWaitInterval}, nil
 		}
 	}
 	if !initRestoreCond && !initOrPVC {
@@ -488,6 +487,7 @@ func (r *RestoreReconciler) cleanupOrphanedVeleroRestores(
 }
 
 func sendResult(restore *v1beta1.Restore, err error) (ctrl.Result, error) {
+	wrapMsg := fmt.Sprintf("could not update status for restore %s/%s", restore.Namespace, restore.Name)
 	if restore.Spec.SyncRestoreWithNewBackups &&
 		restore.IsPhaseEnabled() {
 
@@ -495,20 +495,13 @@ func sendResult(restore *v1beta1.Restore, err error) (ctrl.Result, error) {
 		if restore.Spec.RestoreSyncInterval.Duration != 0 {
 			tryAgain = restore.Spec.RestoreSyncInterval.Duration
 		}
-		return ctrl.Result{RequeueAfter: tryAgain}, errors.Wrap(
-			err,
-			fmt.Sprintf(
-				"could not update status for restore %s/%s",
-				restore.Namespace,
-				restore.Name,
-			),
-		)
+		if err != nil {
+			return ctrl.Result{}, errors.Wrap(err, wrapMsg)
+		}
+		return ctrl.Result{RequeueAfter: tryAgain}, nil
 	}
 
-	return ctrl.Result{}, errors.Wrap(
-		err,
-		fmt.Sprintf("could not update status for restore %s/%s", restore.Namespace, restore.Name),
-	)
+	return ctrl.Result{}, errors.Wrap(err, wrapMsg)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -224,7 +224,10 @@ func (r *BackupScheduleReconciler) Reconcile(
 		if err == nil { // Don't mask previous error
 			err = statusUpdateErr
 		}
-		return ctrl.Result{RequeueAfter: collisionControlInterval}, err
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: collisionControlInterval}, nil
 	}
 
 	// if any velero schedule is deleted manually, recreate them all to have the same backup due time
@@ -232,10 +235,10 @@ func (r *BackupScheduleReconciler) Reconcile(
 		if err := deleteVeleroSchedules(ctx, r.Client, backupSchedule, &veleroScheduleList); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: collisionControlInterval}, errors.Wrap(
-			r.Client.Status().Update(ctx, backupSchedule),
-			updateStatusFailedMsg,
-		)
+		if updErr := r.Client.Status().Update(ctx, backupSchedule); updErr != nil {
+			return ctrl.Result{}, errors.Wrap(updErr, updateStatusFailedMsg)
+		}
+		return ctrl.Result{RequeueAfter: collisionControlInterval}, nil
 	}
 
 	// check for any updates that are required for velero schedules based on backupSchedule and hub resources
@@ -250,15 +253,17 @@ func (r *BackupScheduleReconciler) Reconcile(
 	}
 	setSchedulePhase(&veleroScheduleList, backupSchedule)
 
-	err := r.Client.Status().Update(ctx, backupSchedule)
-	return ctrl.Result{RequeueAfter: collisionControlInterval}, errors.Wrap(
-		err,
-		fmt.Sprintf(
-			"could not update status for schedule %s/%s",
-			backupSchedule.Namespace,
-			backupSchedule.Name,
-		),
-	)
+	if updErr := r.Client.Status().Update(ctx, backupSchedule); updErr != nil {
+		return ctrl.Result{}, errors.Wrap(
+			updErr,
+			fmt.Sprintf(
+				"could not update status for schedule %s/%s",
+				backupSchedule.Namespace,
+				backupSchedule.Name,
+			),
+		)
+	}
+	return ctrl.Result{RequeueAfter: collisionControlInterval}, nil
 }
 
 // validate backup configuration


### PR DESCRIPTION
Related to https://redhat.atlassian.net/browse/ACM-31191

**Summary**

Aligns controller-runtime Reconcile return values with usual patterns: use RequeueAfter without an error when the reconcile should back off and retry, and only return a real error when something failed (typically a failed API write) so the manager does not treat expected requeues as reconcile failures.

**Restore controller (restore_controller.go)**

- validateStorageSettings: Persist error status first; on the retry path return ctrl.Result{RequeueAfter: failureInterval} with nil error after a successful status update (instead of returning a wrapped status-update error together with requeue).
- initVeleroRestores / PVC wait: Same idea—if status update fails, return the error without a requeue; if it succeeds, return the appropriate RequeueAfter with nil error.
- sendResult: For sync restores in the enabled phase, return RequeueAfter with nil on success; on status update failure, return ctrl.Result{} with an error (no requeue mixed with a terminal error return). Centralizes the status-update failure message in a wrapMsg variable.

**Backup schedule controller (schedule_controller.go)**

- After collision / Velero schedule maintenance / normal phase updates: return RequeueAfter: collisionControlInterval with nil error when the status update succeeds.
- Return ctrl.Result{} and the error when the status update fails, instead of attaching the error to a requeue result.

**Motivation**

Returning both RequeueAfter and a non-nil error (or conflating failed status patches with “expected” retries) leads to noisy “Reconciler error” logs and can confuse rate limiting and error handling. Successful backoff should use requeue + nil error; only genuine failures should surface as errors.

**Testing**
Spot-check restore/schedule reconciliation logs for reduced spurious errors when storage validation, init, or status updates trigger requeues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and status update consistency for backup restoration and schedule management operations, ensuring more reliable behavior during reconciliation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->