### PR TITLE
ACM-31191: fix prematurely mark the ACM restore as finished.

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -72,16 +72,22 @@ var veleroBackupNames = map[ResourceType]string{
 	ValidationSchedule:     "acm-validation-policy-schedule",
 }
 
+// isVeleroRestoreFinished reports whether the Velero Restore has reached a terminal phase
+// (success or failure). Non-terminal phases include New, InProgress, plugin wait, and
+// Finalizing* (see RestorePhase in velero.io/v1).
 func isVeleroRestoreFinished(restore *veleroapi.Restore) bool {
-	switch {
-	case restore == nil:
-		return false
-	case len(restore.Status.Phase) == 0 || // if no restore exists
-		restore.Status.Phase == veleroapi.RestorePhaseNew ||
-		restore.Status.Phase == veleroapi.RestorePhaseInProgress:
+	if restore == nil || len(restore.Status.Phase) == 0 {
 		return false
 	}
-	return true
+	switch restore.Status.Phase {
+	case veleroapi.RestorePhaseCompleted,
+		veleroapi.RestorePhasePartiallyFailed,
+		veleroapi.RestorePhaseFailed,
+		veleroapi.RestorePhaseFailedValidation:
+		return true
+	default:
+		return false
+	}
 }
 
 func isVeleroRestoreRunning(restore *veleroapi.Restore) bool {
@@ -182,10 +188,10 @@ func updateRestoreStatus(
 	}
 	restore.Status.LastMessage = msg
 
-	// set CompletionTimestamp when restore is completed
-	restoreCompleted := (restore.Status.Phase == v1beta1.RestorePhaseFinished ||
-		restore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors ||
-		restore.Status.Phase == v1beta1.RestorePhaseError)
+	// Do not set CompletionTimestamp for RestorePhaseError: reconciliation continues and
+	// status can improve after BSL / Velero issues are fixed.
+	restoreCompleted := restore.Status.Phase == v1beta1.RestorePhaseFinished ||
+		restore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors
 	if restoreCompleted {
 		rightNow := metav1.Now()
 		restore.Status.CompletionTimestamp = &rightNow
@@ -281,6 +287,7 @@ func setRestorePhase(
 
 	// get all velero restores and check status for each
 	partiallyFailed := false
+	allveleroRestoresCompleted := true
 	for i := range latestRestores {
 		veleroRestore := latestRestores[i].DeepCopy()
 
@@ -333,7 +340,9 @@ func setRestorePhase(
 			// check if restore status contains the PartiallyFailed string to catch
 			// all variations such as FinalizingPartiallyFailed
 			partiallyFailed = true
-			continue
+		}
+		if !isVeleroRestoreFinished(veleroRestore) {
+			allveleroRestoresCompleted = false
 		}
 	}
 
@@ -347,12 +356,14 @@ func setRestorePhase(
 
 		// delta cleanup needed now
 		cleanupOnEnabled = true
-	} else if partiallyFailed {
-		restore.Status.Phase = v1beta1.RestorePhaseFinishedWithErrors
-		restore.Status.LastMessage = "Velero restores have run to completion but encountered 1+ errors"
-	} else {
-		restore.Status.Phase = v1beta1.RestorePhaseFinished
-		restore.Status.LastMessage = "All Velero restores have run successfully"
+	} else if allveleroRestoresCompleted {
+		if partiallyFailed {
+			restore.Status.Phase = v1beta1.RestorePhaseFinishedWithErrors
+			restore.Status.LastMessage = "Velero restores have run to completion but encountered 1+ errors"
+		} else {
+			restore.Status.Phase = v1beta1.RestorePhaseFinished
+			restore.Status.LastMessage = "All Velero restores have run successfully"
+		}
 	}
 
 	return restore.Status.Phase, cleanupOnEnabled

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -218,7 +218,8 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		return ctrl.Result{}, nil
 
-	} else if restore.Status.Phase == v1beta1.RestorePhaseEnabledError &&
+	} else if (restore.Status.Phase == v1beta1.RestorePhaseEnabledError ||
+		restore.Status.Phase == v1beta1.RestorePhaseError) &&
 		strings.Contains(restore.Status.LastMessage, "BackupStorageLocation") {
 		// if the restore is in enabled error phase, and the storage location is available,
 		// update status based on velero restore status
@@ -297,10 +298,10 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			" ; SyncRestoreWithNewBackups option is ignored because " + msg
 	}
 
-	// Set CompletionTimestamp for terminal phases when cleanupOnRestore was skipped
+	// Set CompletionTimestamp for terminal success phases when cleanupOnRestore was skipped.
+	// Omit RestorePhaseError: restore still reconciles and can recover (e.g. BSL available again).
 	restoreCompleted := restore.Status.Phase == v1beta1.RestorePhaseFinished ||
-		restore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors ||
-		restore.Status.Phase == v1beta1.RestorePhaseError
+		restore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors
 	if restoreCompleted && restore.Status.CompletionTimestamp == nil {
 		rightNow := metav1.Now()
 		restore.Status.CompletionTimestamp = &rightNow
@@ -386,8 +387,7 @@ func (r *RestoreReconciler) cleanupOnRestore(
 	// set CompletionTimestamp when cleanupOnRestore is true or restore is completed
 	// the CompletionTimestamp must be set after cleanupDeltaResources and executePostRestoreTasks are completed
 	restoreCompleted := (acmRestore.Status.Phase == v1beta1.RestorePhaseFinished ||
-		acmRestore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors ||
-		acmRestore.Status.Phase == v1beta1.RestorePhaseError)
+		acmRestore.Status.Phase == v1beta1.RestorePhaseFinishedWithErrors)
 	if cleanupOnRestore || restoreCompleted {
 		rightNow := metav1.Now()
 		acmRestore.Status.CompletionTimestamp = &rightNow

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -55,6 +55,7 @@ func executePostRestoreTasks(
 	acmRestore *v1beta1.Restore,
 ) bool {
 	logger := log.FromContext(ctx)
+	logger.Info("enter executePostRestoreTasks")
 
 	processed := false
 
@@ -88,6 +89,7 @@ func executePostRestoreTasks(
 			managedClusters.Items, localClusterName, time.Now().In(time.UTC))
 		acmRestore.Status.Messages = activationMessages
 	}
+	logger.Info("exit executePostRestoreTasks")
 	return processed
 }
 

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -79,9 +79,19 @@ func Test_isVeleroRestoreFinished(t *testing.T) {
 			args: args{
 				restore: nil,
 			},
+			want: false,
 		},
 		{
-			name: "Finished",
+			name: "empty phase",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{Phase: ""},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Completed",
 			args: args{
 				restore: &veleroapi.Restore{
 					Status: veleroapi.RestoreStatus{
@@ -92,11 +102,77 @@ func Test_isVeleroRestoreFinished(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Not Finished",
+			name: "PartiallyFailed",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{
+						Phase: veleroapi.RestorePhasePartiallyFailed,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Failed",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{
+						Phase: veleroapi.RestorePhaseFailed,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "FailedValidation",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{
+						Phase: veleroapi.RestorePhaseFailedValidation,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "InProgress not finished",
 			args: args{
 				restore: &veleroapi.Restore{
 					Status: veleroapi.RestoreStatus{
 						Phase: veleroapi.RestorePhaseInProgress,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "New not finished",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{
+						Phase: veleroapi.RestorePhaseNew,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Finalizing not finished",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{
+						Phase: veleroapi.RestorePhaseFinalizing,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "WaitingForPluginOperations not finished",
+			args: args{
+				restore: &veleroapi.Restore{
+					Status: veleroapi.RestoreStatus{
+						Phase: veleroapi.RestorePhaseWaitingForPluginOperations,
 					},
 				},
 			},
@@ -494,7 +570,7 @@ func Test_sendResults(t *testing.T) {
 // - Error status for sync restore with valid options -> RestorePhaseEnabledError
 // - Error status for sync restore with invalid options -> RestorePhaseError
 // - Non-error status for sync restore -> unchanged
-// - Completion timestamp setting for finished states
+// - Completion timestamp for Finished / FinishedWithErrors only (not Error — recoverable)
 //
 // Business Logic:
 // Sync restores that encounter errors should be set to EnabledError state
@@ -525,7 +601,7 @@ func Test_updateRestoreStatus(t *testing.T) {
 				veleroResourcesBackupName(latestBackupStr).object,
 			expectedPhase:    v1beta1.RestorePhaseError,
 			expectedMessage:  "restore failed",
-			expectCompletion: true,
+			expectCompletion: false,
 			description:      "Non-sync restore error should be RestorePhaseError",
 		},
 		{
@@ -553,7 +629,7 @@ func Test_updateRestoreStatus(t *testing.T) {
 				veleroResourcesBackupName(skipRestore).object,    // invalid: should be latest
 			expectedPhase:    v1beta1.RestorePhaseError,
 			expectedMessage:  "invalid configuration",
-			expectCompletion: true,
+			expectCompletion: false,
 			description:      "Sync restore with invalid options should be RestorePhaseError",
 		},
 		{
@@ -1138,6 +1214,92 @@ func Test_setRestorePhase(t *testing.T) {
 			},
 			wantPhase:            v1beta1.RestorePhaseEnabledError,
 			wantCleanupOnEnabled: true,
+		},
+		{
+			name: "Velero Finalizing is not finished; leaves ACM phase unchanged (covers allveleroRestoresCompleted=false)",
+			args: args{
+				restore: createACMRestore("Restore", "velero-ns").
+					syncRestoreWithNewBackups(false).
+					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
+					veleroManagedClustersBackupName(latestBackupStr).
+					veleroCredentialsBackupName(latestBackupStr).
+					veleroResourcesBackupName(latestBackupStr).
+					phase(v1beta1.RestorePhaseRunning).object,
+
+				restoreList: &veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero/v1",
+								Kind:       "Restore",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "restore-finalizing",
+								Namespace: "velero-ns",
+							},
+							Spec: veleroapi.RestoreSpec{
+								BackupName: "backup",
+							},
+							Status: veleroapi.RestoreStatus{
+								Phase: veleroapi.RestorePhaseFinalizing,
+							},
+						},
+					},
+				},
+			},
+			wantPhase:            v1beta1.RestorePhaseRunning,
+			wantCleanupOnEnabled: false,
+		},
+		{
+			name: "All Velero restores finished with one PartiallyFailed yields RestorePhaseFinishedWithErrors",
+			args: args{
+				restore: createACMRestore("Restore", "velero-ns").
+					syncRestoreWithNewBackups(false).
+					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
+					veleroManagedClustersBackupName(latestBackupStr).
+					veleroCredentialsBackupName(latestBackupStr).
+					veleroResourcesBackupName(latestBackupStr).
+					phase(v1beta1.RestorePhaseRunning).object,
+
+				restoreList: &veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero/v1",
+								Kind:       "Restore",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "restore-completed",
+								Namespace: "velero-ns",
+							},
+							Spec: veleroapi.RestoreSpec{
+								BackupName: "backup-1",
+							},
+							Status: veleroapi.RestoreStatus{
+								Phase: veleroapi.RestorePhaseCompleted,
+							},
+						},
+						{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero/v1",
+								Kind:       "Restore",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "restore-partially-failed",
+								Namespace: "velero-ns",
+							},
+							Spec: veleroapi.RestoreSpec{
+								BackupName: "backup-2",
+							},
+							Status: veleroapi.RestoreStatus{
+								Phase: veleroapi.RestorePhasePartiallyFailed,
+							},
+						},
+					},
+				},
+			},
+			wantPhase:            v1beta1.RestorePhaseFinishedWithErrors,
+			wantCleanupOnEnabled: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Related jirra https://redhat.atlassian.net/browse/ACM-31191

**Summary**
This change tightens how we treat Velero restore lifecycle and ACM restore completion so that recoverable error states behave correctly and Velero “still running” phases do not prematurely mark the ACM restore as finished.

**Behavior**

- isVeleroRestoreFinished now returns true only for terminal Velero phases: Completed, PartiallyFailed, Failed, and FailedValidation. Phases such as New, InProgress, Finalizing, and plugin-wait states are not treated as finished.
- setRestorePhase tracks allveleroRestoresCompleted so we only move ACM restore to Finished / FinishedWithErrors when every Velero restore has reached a terminal phase. This fixes the case where one restore was still Finalizing but another was already PartiallyFailed (we no longer jump straight to FinishedWithErrors too early). The PartiallyFailed path now runs only when all restores are finished.
- CompletionTimestamp is set only for RestorePhaseFinished and RestorePhaseFinishedWithErrors, not for RestorePhaseError, because reconciliation can continue (e.g. BSL becomes available again). The same rule is applied in Reconcile and cleanupOnRestore.
- BSL recovery: the branch that re-lists Velero restores and calls setRestorePhase when storage was bad but is OK now also runs for RestorePhaseError (in addition to RestorePhaseEnabledError), when LastMessage still indicates a BackupStorageLocation issue.

**Tests**

- Expanded Test_isVeleroRestoreFinished for terminal vs non-terminal phases.
- Test_updateRestoreStatus: expectCompletion: false for RestorePhaseError cases.
- Test_setRestorePhase: Velero Finalizing keeps ACM phase unchanged (allveleroRestoresCompleted = false); mixed Completed + PartiallyFailed → RestorePhaseFinishedWithErrors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved restore completion detection to properly wait for all resources to reach a terminal state before marking restoration as finished.
  * Enhanced error handling for BackupStorageLocation recovery scenarios.
  * Corrected completion timestamp logic for various restore error states.

* **Chores**
  * Added debug logging for restore post-task execution to improve troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->