### PR TITLE
ACM-31191: Restore reconcile: finish path improvements

### DIFF
--- a/controllers/create_helper_test.go
+++ b/controllers/create_helper_test.go
@@ -1052,33 +1052,6 @@ func waitForRestoreStatusFieldValue(
 	}, timeout, interval).Should(BeIdenticalTo(expectedValue))
 }
 
-// updateVeleroRestoreStatusToCompleted updates all velero restores in the list to completed status
-func updateVeleroRestoreStatusToCompleted(
-	ctx context.Context,
-	k8sClient client.Client,
-	restoreNames []string,
-	namespace string,
-	timeout, interval time.Duration,
-) {
-	Eventually(func() error {
-		for _, restoreName := range restoreNames {
-			veleroRestore := &veleroapi.Restore{}
-			err := k8sClient.Get(ctx, createLookupKey(restoreName, namespace), veleroRestore)
-			if err != nil {
-				return err
-			}
-			if veleroRestore.Status.Phase != veleroapi.RestorePhaseCompleted {
-				veleroRestore.Status.Phase = veleroapi.RestorePhaseCompleted
-				err = k8sClient.Update(ctx, veleroRestore)
-				if err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	}, timeout, interval).Should(Succeed())
-}
-
 // verifyVeleroRestoreExists verifies that a velero restore resource exists
 func verifyVeleroRestoreExists(
 	ctx context.Context,

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -291,15 +291,13 @@ func setRestorePhase(
 	for i := range latestRestores {
 		veleroRestore := latestRestores[i].DeepCopy()
 
-		if veleroRestore.Status.Phase == "" {
-			restore.Status.Phase = v1beta1.RestorePhaseUnknown
-			restore.Status.LastMessage = fmt.Sprintf(
-				"Unknown status for Velero restore %s",
-				veleroRestore.Name,
-			)
-			return restore.Status.Phase, cleanupOnEnabled
+		veleroPhase := veleroRestore.Status.Phase
+		if veleroPhase == "" {
+			// Treat unset status like Velero's "new" until the controller populates it, so we do not
+			// flip the ACM restore to Unknown while status is still propagating to the apiserver/cache.
+			veleroPhase = veleroapi.RestorePhaseNew
 		}
-		if veleroRestore.Status.Phase == veleroapi.RestorePhaseNew {
+		if veleroPhase == veleroapi.RestorePhaseNew {
 			restore.Status.Phase = v1beta1.RestorePhaseStarted
 			restore.Status.LastMessage = fmt.Sprintf(
 				"Velero restore %s has started",

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -257,8 +257,11 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	initRestoreCond := len(veleroRestoreList.Items) == 0 || sync
 
 	initOrPVC := initRestoreCond || isPVCStep
+	var noNewVeleroRestoreCreated bool
 	if initOrPVC {
-		mustwait, waitmsg, err := r.initVeleroRestores(ctx, restore, sync, &veleroRestoreList)
+		var mustwait bool
+		var waitmsg string
+		mustwait, waitmsg, err, noNewVeleroRestoreCreated = r.initVeleroRestores(ctx, restore, sync, &veleroRestoreList)
 		if err != nil {
 			msg := fmt.Sprintf(
 				"unable to initialize Velero restores for restore %s/%s: %v",
@@ -285,7 +288,11 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{RequeueAfter: pvcWaitInterval}, nil
 		}
 	}
-	if !initRestoreCond && !initOrPVC {
+	// Run cleanup when past init (classic path) or when init ran but every Velero Restore Create was
+	// AlreadyExists (no new Velero objects this pass). In the latter case initOrPVC can stay true
+	// (e.g. sync), so cleanup must not be skipped or setRestorePhase never runs and the restore stalls.
+	cleanupEligible := (!initRestoreCond && !initOrPVC) || (initOrPVC && noNewVeleroRestoreCreated)
+	if cleanupEligible {
 		r.cleanupOnRestore(ctx, restore)
 	}
 
@@ -643,7 +650,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 	restore *v1beta1.Restore,
 	sync bool,
 	veleroRestoreList *veleroapi.RestoreList,
-) (bool, string, error) {
+) (bool, string, error, bool) {
 	restoreLogger := log.FromContext(ctx)
 
 	restoreOnlyManagedClusters := false
@@ -666,7 +673,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 			// check if any tracked restore is missing from the cluster
 			trackedRestoresMissing := areTrackedRestoresMissing(restore, veleroRestoreList)
 			if !trackedRestoresMissing {
-				return false, "", nil
+				return false, "", nil, true
 			}
 			restoreLogger.Info(
 				"tracked Velero restore(s) missing, will recreate",
@@ -685,7 +692,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 		restoreOnlyManagedClusters,
 	)
 	if err != nil {
-		return false, "", err
+		return false, "", err, false
 	}
 	if len(veleroRestoresToCreate) == 0 {
 		updateRestoreStatus(
@@ -694,10 +701,11 @@ func (r *RestoreReconciler) initVeleroRestores(
 			fmt.Sprintf(noopMsg, restore.Name),
 			restore,
 		)
-		return false, "", nil
+		return false, "", nil, false
 	}
 
 	newVeleroRestoreCreated := false
+	anyVeleroCreateFailed := false
 
 	// now create the restore resources and start the actual restore
 	for resKey := range resKeys {
@@ -725,6 +733,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 
 		if err != nil {
 			if !k8serr.IsAlreadyExists(err) {
+				anyVeleroCreateFailed = true
 				// log the error only if it is not an already exists error
 				restoreLogger.Info(
 					fmt.Sprintf("unable to create Velero restore for restore %s:%s, error:%s",
@@ -764,7 +773,7 @@ func (r *RestoreReconciler) initVeleroRestores(
 			if shouldWait, waitMsg := processRestoreWait(ctx, r.Client,
 				veleroRestoresToCreate[key].Name, restore.Namespace); shouldWait {
 				// some PVCs were not created yet, wait for them
-				return true, waitMsg, nil
+				return true, waitMsg, nil, false
 			}
 		}
 	}
@@ -772,11 +781,11 @@ func (r *RestoreReconciler) initVeleroRestores(
 	if newVeleroRestoreCreated {
 		restore.Status.Phase = v1beta1.RestorePhaseStarted
 		restore.Status.LastMessage = fmt.Sprintf("Restore %s started", restore.Name)
-	} else {
-		restore.Status.Phase = v1beta1.RestorePhaseFinished
-		restore.Status.LastMessage = fmt.Sprintf("Restore %s completed", restore.Name)
 	}
-	return false, "", nil
+	// Signal cleanup when no new Velero Restore was created (e.g. all Create returned AlreadyExists)
+	// without non-AlreadyExists failures — cleanup runs setRestorePhase / post-restore work.
+	noNewVeleroRestore := !newVeleroRestoreCreated && !anyVeleroCreateFailed
+	return false, "", nil, noNewVeleroRestore
 }
 
 // for an activation phase update restore labels to include activation resources

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Basic Restore controller", func() {
 	var (
 		// Core test context and timing
 		ctx      context.Context          // Test execution context
-		timeout  = time.Second * 10       // Maximum wait time for async operations
+		timeout  = time.Second * 30       // Maximum wait time for async operations
 		interval = time.Millisecond * 250 // Polling interval for Eventually/Consistently checks
 
 		// Velero infrastructure components
@@ -377,8 +377,8 @@ var _ = Describe("Basic Restore controller", func() {
 				veleroRestores := veleroapi.RestoreList{}
 				Expect(k8sClient.List(ctx, &veleroRestores, client.InNamespace(veleroNamespace.Name))).To(Succeed())
 
-				// Initialize all Velero restore statuses to avoid "Unknown" phase
-				// The controller checks all restores, and if any have empty status, ACM restore goes to Unknown
+				// Initialize all Velero restore statuses so Velero phases are explicit before completion
+				// (empty status is treated like New in setRestorePhase; tests still set New for clarity)
 				for i := range veleroRestores.Items {
 					if veleroRestores.Items[i].Status.Phase == "" {
 						veleroRestores.Items[i].Status.Phase = veleroapi.RestorePhaseNew
@@ -397,7 +397,6 @@ var _ = Describe("Basic Restore controller", func() {
 					Values:   []string{"bar2"},
 				}
 
-				restoreNames := []string{}
 				for i := range veleroRestores.Items {
 					// look for velero optional properties
 					Expect(*veleroRestores.Items[i].Spec.RestorePVs).Should(BeTrue())
@@ -437,19 +436,28 @@ var _ = Describe("Basic Restore controller", func() {
 
 					// Verify backup name is set
 					Expect(veleroRestores.Items[i].Spec.BackupName).ShouldNot(BeEmpty())
-
-					restoreNames = append(restoreNames, veleroRestores.Items[i].GetName())
 				}
 
-				// Now update all the velero restores to simulate that they are complete
-				updateVeleroRestoreStatusToCompleted(ctx, k8sClient, restoreNames, veleroNamespace.Name, timeout, interval)
-
-				// TODO: there's a lot more steps in the restore that could be
-				// tested here
-
-				// Now the acm restore should proceed to Finished phase
-				waitForRestorePhase(ctx, k8sClient, restoreName, veleroNamespace.Name,
-					v1beta1.RestorePhaseFinished, timeout, interval)
+				// Poll until ACM restore reaches Finished: keep Velero restores Completed on each tick
+				// (same pattern as completeVeleroRestoresUntilPhase) so the controller always observes
+				// a consistent completed set while reconciling.
+				Eventually(func() v1beta1.RestorePhase {
+					veleroRestoresPoll := veleroapi.RestoreList{}
+					if err := k8sClient.List(ctx, &veleroRestoresPoll, client.InNamespace(veleroNamespace.Name)); err != nil {
+						return ""
+					}
+					for i := range veleroRestoresPoll.Items {
+						if veleroRestoresPoll.Items[i].Status.Phase != veleroapi.RestorePhaseCompleted {
+							veleroRestoresPoll.Items[i].Status.Phase = veleroapi.RestorePhaseCompleted
+							_ = k8sClient.Update(ctx, &veleroRestoresPoll.Items[i])
+						}
+					}
+					acm := v1beta1.Restore{}
+					if err := k8sClient.Get(ctx, restoreLookupKey, &acm); err != nil {
+						return ""
+					}
+					return acm.Status.Phase
+				}, timeout, interval).Should(BeEquivalentTo(v1beta1.RestorePhaseFinished))
 				// When acm restore is finished CompletionTimestamp should be set
 				waitForCompletionTimestamp(ctx, k8sClient, restoreName, veleroNamespace.Name,
 					timeout, interval)
@@ -683,7 +691,7 @@ var _ = Describe("Basic Restore controller", func() {
 					"rhacm-restore-1-acm-resources-schedule-good-old-backup", timeout, interval)
 
 				waitForRestorePhase(ctx, k8sClient, restoreName, veleroNamespace.Name,
-					v1beta1.RestorePhaseUnknown, timeout, interval)
+					v1beta1.RestorePhaseStarted, timeout, interval)
 
 				verifyVeleroRestoreExists(ctx, k8sClient,
 					restoreName+"-acm-credentials-schedule-good-old-backup", veleroNamespace.Name)
@@ -995,7 +1003,7 @@ var _ = Describe("Basic Restore controller", func() {
 				setRestorePhase(&veleroRestores, &createdRestore)
 				Expect(
 					createdRestore.Status.Phase,
-				).Should(BeEquivalentTo(v1beta1.RestorePhaseUnknown))
+				).Should(BeEquivalentTo(v1beta1.RestorePhaseStarted))
 
 				veleroRestores.Items[0].Status.Phase = veleroapi.RestorePhaseNew
 				setRestorePhase(&veleroRestores, &createdRestore)

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -441,23 +441,28 @@ var _ = Describe("Basic Restore controller", func() {
 				// Poll until ACM restore reaches Finished: keep Velero restores Completed on each tick
 				// (same pattern as completeVeleroRestoresUntilPhase) so the controller always observes
 				// a consistent completed set while reconciling.
-				Eventually(func() v1beta1.RestorePhase {
+				Eventually(func() error {
 					veleroRestoresPoll := veleroapi.RestoreList{}
 					if err := k8sClient.List(ctx, &veleroRestoresPoll, client.InNamespace(veleroNamespace.Name)); err != nil {
-						return ""
+						return err
 					}
 					for i := range veleroRestoresPoll.Items {
 						if veleroRestoresPoll.Items[i].Status.Phase != veleroapi.RestorePhaseCompleted {
 							veleroRestoresPoll.Items[i].Status.Phase = veleroapi.RestorePhaseCompleted
-							_ = k8sClient.Update(ctx, &veleroRestoresPoll.Items[i])
+							if err := k8sClient.Update(ctx, &veleroRestoresPoll.Items[i]); err != nil {
+								return err
+							}
 						}
 					}
 					acm := v1beta1.Restore{}
 					if err := k8sClient.Get(ctx, restoreLookupKey, &acm); err != nil {
-						return ""
+						return err
 					}
-					return acm.Status.Phase
-				}, timeout, interval).Should(BeEquivalentTo(v1beta1.RestorePhaseFinished))
+					if acm.Status.Phase != v1beta1.RestorePhaseFinished {
+						return fmt.Errorf("restore phase=%s, want=%s", acm.Status.Phase, v1beta1.RestorePhaseFinished)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed())
 				// When acm restore is finished CompletionTimestamp should be set
 				waitForCompletionTimestamp(ctx, k8sClient, restoreName, veleroNamespace.Name,
 					timeout, interval)

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -28,9 +28,11 @@ import (
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -1140,6 +1142,42 @@ func Test_setRestorePhase(t *testing.T) {
 				restoreList: nil,
 			},
 			wantPhase:            v1beta1.RestorePhaseEnabled,
+			wantCleanupOnEnabled: false,
+		},
+		{
+			name: "Velero restore with empty Status.Phase is treated like New (ACM Started)",
+			args: args{
+				restore: createACMRestore("Restore", "velero-ns").
+					syncRestoreWithNewBackups(false).
+					cleanupBeforeRestore(v1beta1.CleanupTypeNone).
+					veleroManagedClustersBackupName(latestBackupStr).
+					veleroCredentialsBackupName(latestBackupStr).
+					veleroResourcesBackupName(latestBackupStr).
+					veleroCredentialsRestoreName("one-creds-restore").
+					phase(v1beta1.RestorePhaseRunning).object,
+
+				restoreList: &veleroapi.RestoreList{
+					Items: []veleroapi.Restore{
+						{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero/v1",
+								Kind:       "Restore",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "one-creds-restore",
+								Namespace: "velero-ns",
+							},
+							Spec: veleroapi.RestoreSpec{
+								BackupName: "backup",
+							},
+							Status: veleroapi.RestoreStatus{
+								Phase: "",
+							},
+						},
+					},
+				},
+			},
+			wantPhase:            v1beta1.RestorePhaseStarted,
 			wantCleanupOnEnabled: false,
 		},
 		{
@@ -4992,6 +5030,26 @@ func (f *failVeleroRestoreCreateClient) Create(
 	return f.Client.Create(ctx, obj, opts...)
 }
 
+var veleroRestoresGroupResource = schema.GroupResource{Group: "velero.io", Resource: "restores"}
+
+// alreadyExistsVeleroRestoreCreateClient returns AlreadyExists for velero.io.Restore Create calls.
+type alreadyExistsVeleroRestoreCreateClient struct {
+	client.Client
+	veleroRestoreCreateCalls int
+}
+
+func (a *alreadyExistsVeleroRestoreCreateClient) Create(
+	ctx context.Context,
+	obj client.Object,
+	opts ...client.CreateOption,
+) error {
+	if _, ok := obj.(*veleroapi.Restore); ok {
+		a.veleroRestoreCreateCalls++
+		return apierrors.NewAlreadyExists(veleroRestoresGroupResource, obj.GetName())
+	}
+	return a.Client.Create(ctx, obj, opts...)
+}
+
 // Test_initVeleroRestores_nonAlreadyExistsCreateFailure_returnsNil verifies that when every
 // Velero Restore Create fails with a non-AlreadyExists error, initVeleroRestores still returns
 // (nil, nil, nil) and attempts Create once per restore to create (here: credentials, resources,
@@ -5042,13 +5100,136 @@ func Test_initVeleroRestores_nonAlreadyExistsCreateFailure_returnsNil(t *testing
 	}
 
 	emptyVelero := veleroapi.RestoreList{}
-	_, _, err := r.initVeleroRestores(ctx, acm, false, &emptyVelero)
+	_, _, err, noNewVeleroRestore := r.initVeleroRestores(ctx, acm, false, &emptyVelero)
 	if err != nil {
 		t.Fatalf("initVeleroRestores: %v", err)
+	}
+	if noNewVeleroRestore {
+		t.Fatalf("want noNewVeleroRestore false when any Create fails with non-AlreadyExists, got true")
+	}
+	// Init must not mark ACM Restore Finished when no Velero Restore was created (Create failed);
+	// terminal phase and message are set after cleanup / post-restore / setRestorePhase.
+	if acm.Status.Phase == v1beta1.RestorePhaseFinished {
+		t.Fatalf("initVeleroRestores set Finished with no successful Create; got LastMessage=%q",
+			acm.Status.LastMessage)
 	}
 	const wantVeleroRestoreCreates = 3
 	if c.veleroRestoreCreateCalls != wantVeleroRestoreCreates {
 		t.Fatalf("Velero Restore Create calls = %d, want %d (each planned restore should attempt Create)",
 			c.veleroRestoreCreateCalls, wantVeleroRestoreCreates)
+	}
+}
+
+// Test_initVeleroRestores_allVeleroCreateAlreadyExists_returnsFourthTrue verifies the fourth return
+// (noNewVeleroRestore) is true when every Velero Restore Create returns AlreadyExists and no
+// non-AlreadyExists failure occurred — Reconcile uses this to run cleanup/setRestorePhase.
+func Test_initVeleroRestores_allVeleroCreateAlreadyExists_returnsFourthTrue(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	ts := "20240101120000"
+	clusterLbl := map[string]string{
+		BackupVeleroLabel:          "aa",
+		BackupScheduleClusterLabel: "cls",
+	}
+	cred := *createBackup("acm-credentials-schedule-"+ts, ns).labels(clusterLbl).object
+	res := *createBackup("acm-resources-schedule-"+ts, ns).labels(clusterLbl).object
+	gen := *createBackup("acm-resources-generic-schedule-"+ts, ns).labels(clusterLbl).object
+
+	acm := createACMRestore("restore-init-already-exists", ns).
+		syncRestoreWithNewBackups(false).
+		cleanupBeforeRestore(v1beta1.CleanupTypeRestored).
+		veleroManagedClustersBackupName(skipRestoreStr).
+		veleroCredentialsBackupName(latestBackupStr).
+		veleroResourcesBackupName(latestBackupStr).
+		phase(v1beta1.RestorePhaseStarted).
+		object
+
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := veleroapi.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(acm, &cred, &res, &gen).
+		Build()
+
+	c := &alreadyExistsVeleroRestoreCreateClient{Client: base}
+
+	r := &RestoreReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
+	}
+
+	emptyVelero := veleroapi.RestoreList{}
+	mustWait, waitMsg, err, noNewVeleroRestore := r.initVeleroRestores(ctx, acm, false, &emptyVelero)
+	if err != nil {
+		t.Fatalf("initVeleroRestores: %v", err)
+	}
+	if mustWait {
+		t.Fatalf("unexpected mustWait: %s", waitMsg)
+	}
+	if !noNewVeleroRestore {
+		t.Fatalf("want noNewVeleroRestore true when all Creates are AlreadyExists, got false")
+	}
+	const wantCreates = 3
+	if c.veleroRestoreCreateCalls != wantCreates {
+		t.Fatalf("Velero Restore Create calls = %d, want %d", c.veleroRestoreCreateCalls, wantCreates)
+	}
+}
+
+// Test_initVeleroRestores_sync_trackedRestoresNotMissing_returnsFourthTrue covers the sync path that
+// returns early when no new backups are available, managed clusters are not in the "latest-only"
+// activation sub-path, and no tracked Velero restore name is missing from the cluster.
+func Test_initVeleroRestores_sync_trackedRestoresNotMissing_returnsFourthTrue(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	acm := createACMRestore("restore-sync-early-exit", ns).
+		syncRestoreWithNewBackups(true).
+		veleroManagedClustersBackupName(skipRestoreStr).
+		veleroCredentialsBackupName(latestBackupStr).
+		veleroResourcesBackupName(latestBackupStr).
+		phase(v1beta1.RestorePhaseStarted).
+		object
+
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := veleroapi.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(acm).
+		Build()
+
+	r := &RestoreReconciler{
+		Client:   base,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	emptyVelero := veleroapi.RestoreList{}
+	mustWait, waitMsg, err, noNewVeleroRestore := r.initVeleroRestores(ctx, acm, true, &emptyVelero)
+	if err != nil {
+		t.Fatalf("initVeleroRestores: %v", err)
+	}
+	if mustWait {
+		t.Fatalf("unexpected mustWait: %s", waitMsg)
+	}
+	if !noNewVeleroRestore {
+		t.Fatalf("want noNewVeleroRestore true for sync early exit (tracked not missing), got false")
 	}
 }


### PR DESCRIPTION
Jirra https://redhat.atlassian.net/browse/ACM-31191

**Title**
Restore reconcile: finish path when Velero Create is AlreadyExists, empty Velero phase handling, and tests

**Description**

**Summary**
This change fixes restore reconciliation when Velero Restore objects already exist (AlreadyExists on create), treats an empty Velero Status.Phase like New instead of flipping the ACM Restore to Unknown, and extends unit/integration coverage. The operator entrypoint is also adjusted for optional webhook and simpler startup (see Operational / runtime below).

**Problem**
	•	initVeleroRestores could return without creating new Velero resources (e.g. every Create returned AlreadyExists), but cleanupOnRestore / setRestorePhase were skipped because the reconcile path only ran cleanup when !initRestoreCond && !initOrPVC. That could leave the ACM Restore stuck and never reaching a correct terminal phase.
	•	initVeleroRestores could set RestorePhaseFinished when no new Velero restore was created, which is not a reliable “success” signal; cleanup and post-restore steps still need to run.
	•	Empty Velero Status.Phase was mapped to RestorePhaseUnknown, which is noisy when status has not yet propagated.
	
**Solution**
	•	initVeleroRestores now returns a fourth value noNewVeleroRestore (true when no new Velero restore was created and no non–AlreadyExists create failure).
	•	Reconcile computes cleanupEligible so cleanup runs on the classic path or when init ran and noNewVeleroRestoreCreated is true (e.g. all creates AlreadyExists).
	•	anyVeleroCreateFailed tracks non–AlreadyExists errors so noNewVeleroRestore stays false when creates actually fail.
	•	setRestorePhase: coerce empty Velero phase to RestorePhaseNew before ACM phase logic so ACM RestorePhaseStarted is used instead of Unknown.
	
**Tests**
	•	restore_test.go: initVeleroRestores cases for non–AlreadyExists failure (fourth return false), all AlreadyExists (fourth true), sync early-exit (fourth true); Test_setRestorePhase row for empty Velero phase → Started.
	•	restore_controller_test.go: expectations updated from RestorePhaseUnknown to RestorePhaseStarted where Velero phase is empty/new

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize empty Velero restore phases to "New" instead of treating them as Unknown.

* **Refactor**
  * Reconciler now tracks whether any new Velero restores were created and conditions cleanup accordingly.
  * Removed automatic completion marking when no new restores are created; phase transitions updated.

* **Tests**
  * Increased async timeouts and replaced a one-shot helper with polling to drive Velero restore completion.
  * Added tests covering "all creates AlreadyExists" and related return-value behavior; updated assertions to the new phase expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->