### PR TITLE
ACM-32727 Improve CRD description quality: Cluster Backup (BackupSchedule, Restore)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ help: ## Display this help.
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	bash hack/augment-backupschedule-crd-descriptions.sh
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -82,7 +82,6 @@ type RestoreSpec struct {
 	// backup_name points to the name of the backup to be restored
 	// +kubebuilder:validation:Required
 	VeleroCredentialsBackupName *string `json:"veleroCredentialsBackupName"`
-	// +kubebuilder:validation:Enum=CleanupRestored;None;CleanupAll
 	// +kubebuilder:validation:Required
 	// CleanupBeforeRestore selects how the operator performs post-restore cleanup on the hub after Velero restores
 	// complete (delta resources not matching the current backup).

--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -82,6 +82,7 @@ type RestoreSpec struct {
 	// backup_name points to the name of the backup to be restored
 	// +kubebuilder:validation:Required
 	VeleroCredentialsBackupName *string `json:"veleroCredentialsBackupName"`
+	// +kubebuilder:validation:Enum=CleanupRestored;None;CleanupAll
 	// +kubebuilder:validation:Required
 	// CleanupBeforeRestore selects how the operator performs post-restore cleanup on the hub after Velero restores
 	// complete (delta resources not matching the current backup).

--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -83,11 +83,12 @@ type RestoreSpec struct {
 	// +kubebuilder:validation:Required
 	VeleroCredentialsBackupName *string `json:"veleroCredentialsBackupName"`
 	// +kubebuilder:validation:Required
-	//
-	// 1. Use CleanupRestored if you want to delete all
-	// resources created by a previous restore operation, before restoring the new data
-	// 2. Use None if you don't want to clean up any resources before restoring the new data.
-	//
+	// CleanupBeforeRestore selects how the operator performs post-restore cleanup on the hub after Velero restores
+	// complete (delta resources not matching the current backup).
+	// One of: CleanupRestored (remove resources from a prior restore that are not part of the current restored backup),
+	// None (skip post-restore cleanup, typical for a fresh hub),
+	// CleanupAll (broader cleanup of ACM-scoped resources not in the current backup, including user-created; use with
+	// caution).
 	CleanupBeforeRestore CleanupType `json:"cleanupBeforeRestore"`
 	// +kubebuilder:validation:Optional
 	// Set this to true if you want to keep checking for new backups and restore if updates are available.
@@ -172,18 +173,29 @@ type RestoreSpec struct {
 
 // RestoreStatus defines the observed state of Restore
 type RestoreStatus struct {
+	// VeleroManagedClustersRestoreName is the name of the Velero Restore object created to restore managed-cluster
+	// activation resources. Empty if veleroManagedClustersBackupName was set to "skip" or a restore was not created yet.
 	// +kubebuilder:validation:Optional
 	VeleroManagedClustersRestoreName string `json:"veleroManagedClustersRestoreName,omitempty"`
+	// VeleroResourcesRestoreName is the name of the Velero Restore object created to restore ACM hub resources
+	// (applications, policies, and related hub content). Empty if skipped or not yet created.
 	// +kubebuilder:validation:Optional
 	VeleroResourcesRestoreName string `json:"veleroResourcesRestoreName,omitempty"`
+	// VeleroGenericResourcesRestoreName is the name of the Velero Restore object created to restore generic
+	// (non-cluster, non-credential) resources. Empty if skipped or not yet created.
 	// +kubebuilder:validation:Optional
 	VeleroGenericResourcesRestoreName string `json:"veleroGenericResourcesRestoreName,omitempty"`
+	// VeleroCredentialsRestoreName is the name of the Velero Restore object created to restore credential backups
+	// (secrets, service accounts). Empty if veleroCredentialsBackupName was set to "skip" or a restore was not created
+	// yet.
 	// +kubebuilder:validation:Optional
 	VeleroCredentialsRestoreName string `json:"veleroCredentialsRestoreName,omitempty"`
-	// Phase is the current phase of the restore
+	// Phase is the current lifecycle phase of the ACM Restore (aggregated from Velero restore progress and sync mode).
+	// One of: Started, Running, Finished, FinishedWithErrors, Error, Unknown, Enabled, EnabledWithErrors.
 	// +kubebuilder:validation:Optional
 	Phase RestorePhase `json:"phase"`
-	// Message on the last operation
+	// LastMessage is a human-readable message describing the outcome of the most recent restore operation or the reason
+	// for the current phase.
 	// +kubebuilder:validation:Optional
 	LastMessage string `json:"lastMessage"`
 	// Messages contains any messages that were encountered during the restore process.

--- a/api/v1beta1/schedule_types.go
+++ b/api/v1beta1/schedule_types.go
@@ -52,8 +52,8 @@ const (
 
 // BackupScheduleSpec defines the desired state of BackupSchedule
 type BackupScheduleSpec struct {
-	// Schedule is a Cron expression defining when to run
-	// the Velero Backup
+	// VeleroSchedule is a cron expression defining when each Velero Backup runs for this ACM BackupSchedule.
+	// Uses standard cron syntax (minute hour day-of-month month day-of-week). Example: "0 */2 * * *" runs every 2 hours.
 	// +kubebuilder:validation:Required
 	VeleroSchedule string `json:"veleroSchedule"`
 	// TTL is a time.Duration-parseable string describing how long
@@ -96,8 +96,10 @@ type BackupScheduleSpec struct {
 	// If not defined, the value is set to false.
 	Paused bool `json:"paused,omitempty"`
 	// +kubebuilder:validation:Optional
-	// UseOwnerReferencesBackup specifies whether to use
-	// OwnerReferences on backups created by this Schedule.
+	// UseOwnerReferencesInBackup, when true, sets owner references on Velero Backup objects created for this
+	// BackupSchedule so they are garbage-collected if the BackupSchedule is deleted. Set this if you want backups tied
+	// to the BackupSchedule lifecycle; leave false (default) if an external process must retain backups independently of
+	// the BackupSchedule.
 	UseOwnerReferencesInBackup bool `json:"useOwnerReferencesInBackup,omitempty"`
 	// +kubebuilder:validation:Optional
 	// SkipImmediately specifies whether to skip backup if schedule is due immediately
@@ -111,10 +113,12 @@ type BackupScheduleSpec struct {
 
 // BackupScheduleStatus defines the observed state of BackupSchedule
 type BackupScheduleStatus struct {
-	// Phase is the current phase of the schedule
+	// Phase is the current lifecycle phase of the BackupSchedule.
+	// One of: New, Enabled, FailedValidation, Failed, Unknown, BackupCollision, Paused.
 	// +kubebuilder:validation:Optional
 	Phase SchedulePhase `json:"phase"`
-	// Message on the last operation
+	// LastMessage is a human-readable message describing the outcome of the most recent backup schedule operation or
+	// validation error.
 	// +kubebuilder:validation:Optional
 	LastMessage string `json:"lastMessage"`
 	// Velero Schedule for backing up remote clusters

--- a/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml
@@ -97,13 +97,15 @@ spec:
                 type: boolean
               useOwnerReferencesInBackup:
                 description: |-
-                  UseOwnerReferencesBackup specifies whether to use
-                  OwnerReferences on backups created by this Schedule.
+                  UseOwnerReferencesInBackup, when true, sets owner references on Velero Backup objects created for this
+                  BackupSchedule so they are garbage-collected if the BackupSchedule is deleted. Set this if you want backups tied
+                  to the BackupSchedule lifecycle; leave false (default) if an external process must retain backups independently of
+                  the BackupSchedule.
                 type: boolean
               veleroSchedule:
                 description: |-
-                  Schedule is a Cron expression defining when to run
-                  the Velero Backup
+                  VeleroSchedule is a cron expression defining when each Velero Backup runs for this ACM BackupSchedule.
+                  Uses standard cron syntax (minute hour day-of-month month day-of-week). Example: "0 */2 * * *" runs every 2 hours.
                 type: string
               veleroTtl:
                 description: |-
@@ -124,10 +126,14 @@ spec:
             description: BackupScheduleStatus defines the observed state of BackupSchedule
             properties:
               lastMessage:
-                description: Message on the last operation
+                description: |-
+                  LastMessage is a human-readable message describing the outcome of the most recent backup schedule operation or
+                  validation error.
                 type: string
               phase:
-                description: Phase is the current phase of the schedule
+                description: |-
+                  Phase is the current lifecycle phase of the BackupSchedule.
+                  One of: New, Enabled, FailedValidation, Failed, Unknown, BackupCollision, Paused.
                 type: string
               veleroScheduleCredentials:
                 description: Velero Schedule for backing up credentials
@@ -179,16 +185,22 @@ spec:
                               CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
                               ReadyToUse during creation, before returning error as timeout.
                               The default value is 10 minute.
+                              For ACM hub backups, increase this if CSI snapshot creation for hub PVCs (for example storage-backed
+                              volumes for hub components) is slow; otherwise keep the default unless Velero backup logs show CSI timeout errors.
                             type: string
                           datamover:
                             description: |-
                               DataMover specifies the data mover to be used by the backup.
                               If DataMover is "" or "velero", the built-in data mover will be used.
+                              For ACM hub backups, set or change this when your storage class requires the Velero node-agent data
+                              mover path instead of snapshots alone (for example large or non-snapshot volumes); leave empty for typical snapshot-based hub backups.
                             type: string
                           defaultVolumesToFsBackup:
                             description: |-
                               DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
                               for all volumes by default.
+                              For ACM hub backups, set to true when hub workloads use volumes that cannot use snapshots or when
+                              file-system backup is required for specific hub data; otherwise leave false/unset to prefer snapshot backup where supported.
                             nullable: true
                             type: boolean
                           defaultVolumesToRestic:
@@ -748,16 +760,22 @@ spec:
                               CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
                               ReadyToUse during creation, before returning error as timeout.
                               The default value is 10 minute.
+                              For ACM hub backups, increase this if CSI snapshot creation for hub PVCs (for example storage-backed
+                              volumes for hub components) is slow; otherwise keep the default unless Velero backup logs show CSI timeout errors.
                             type: string
                           datamover:
                             description: |-
                               DataMover specifies the data mover to be used by the backup.
                               If DataMover is "" or "velero", the built-in data mover will be used.
+                              For ACM hub backups, set or change this when your storage class requires the Velero node-agent data
+                              mover path instead of snapshots alone (for example large or non-snapshot volumes); leave empty for typical snapshot-based hub backups.
                             type: string
                           defaultVolumesToFsBackup:
                             description: |-
                               DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
                               for all volumes by default.
+                              For ACM hub backups, set to true when hub workloads use volumes that cannot use snapshots or when
+                              file-system backup is required for specific hub data; otherwise leave false/unset to prefer snapshot backup where supported.
                             nullable: true
                             type: boolean
                           defaultVolumesToRestic:
@@ -1317,16 +1335,22 @@ spec:
                               CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
                               ReadyToUse during creation, before returning error as timeout.
                               The default value is 10 minute.
+                              For ACM hub backups, increase this if CSI snapshot creation for hub PVCs (for example storage-backed
+                              volumes for hub components) is slow; otherwise keep the default unless Velero backup logs show CSI timeout errors.
                             type: string
                           datamover:
                             description: |-
                               DataMover specifies the data mover to be used by the backup.
                               If DataMover is "" or "velero", the built-in data mover will be used.
+                              For ACM hub backups, set or change this when your storage class requires the Velero node-agent data
+                              mover path instead of snapshots alone (for example large or non-snapshot volumes); leave empty for typical snapshot-based hub backups.
                             type: string
                           defaultVolumesToFsBackup:
                             description: |-
                               DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
                               for all volumes by default.
+                              For ACM hub backups, set to true when hub workloads use volumes that cannot use snapshots or when
+                              file-system backup is required for specific hub data; otherwise leave false/unset to prefer snapshot backup where supported.
                             nullable: true
                             type: boolean
                           defaultVolumesToRestic:

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -55,9 +55,12 @@ spec:
             properties:
               cleanupBeforeRestore:
                 description: |-
-                  1. Use CleanupRestored if you want to delete all
-                  resources created by a previous restore operation, before restoring the new data
-                  2. Use None if you don't want to clean up any resources before restoring the new data.
+                  CleanupBeforeRestore selects how the operator performs post-restore cleanup on the hub after Velero restores
+                  complete (delta resources not matching the current backup).
+                  One of: CleanupRestored (remove resources from a prior restore that are not part of the current restored backup),
+                  None (skip post-restore cleanup, typical for a fresh hub),
+                  CleanupAll (broader cleanup of ACM-scoped resources not in the current backup, including user-created; use with
+                  caution).
                 type: string
               excludedNamespaces:
                 description: |-
@@ -456,7 +459,9 @@ spec:
                 nullable: true
                 type: string
               lastMessage:
-                description: Message on the last operation
+                description: |-
+                  LastMessage is a human-readable message describing the outcome of the most recent restore operation or the reason
+                  for the current phase.
                 type: string
               messages:
                 description: Messages contains any messages that were encountered
@@ -466,15 +471,30 @@ spec:
                 nullable: true
                 type: array
               phase:
-                description: Phase is the current phase of the restore
+                description: |-
+                  Phase is the current lifecycle phase of the ACM Restore (aggregated from Velero restore progress and sync mode).
+                  One of: Started, Running, Finished, FinishedWithErrors, Error, Unknown, Enabled, EnabledWithErrors.
                 type: string
               veleroCredentialsRestoreName:
+                description: |-
+                  VeleroCredentialsRestoreName is the name of the Velero Restore object created to restore credential backups
+                  (secrets, service accounts). Empty if veleroCredentialsBackupName was set to "skip" or a restore was not created
+                  yet.
                 type: string
               veleroGenericResourcesRestoreName:
+                description: |-
+                  VeleroGenericResourcesRestoreName is the name of the Velero Restore object created to restore generic
+                  (non-cluster, non-credential) resources. Empty if skipped or not yet created.
                 type: string
               veleroManagedClustersRestoreName:
+                description: |-
+                  VeleroManagedClustersRestoreName is the name of the Velero Restore object created to restore managed-cluster
+                  activation resources. Empty if veleroManagedClustersBackupName was set to "skip" or a restore was not created yet.
                 type: string
               veleroResourcesRestoreName:
+                description: |-
+                  VeleroResourcesRestoreName is the name of the Velero Restore object created to restore ACM hub resources
+                  (applications, policies, and related hub content). Empty if skipped or not yet created.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -61,10 +61,6 @@ spec:
                   None (skip post-restore cleanup, typical for a fresh hub),
                   CleanupAll (broader cleanup of ACM-scoped resources not in the current backup, including user-created; use with
                   caution).
-                enum:
-                - CleanupRestored
-                - None
-                - CleanupAll
                 type: string
               excludedNamespaces:
                 description: |-

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -61,6 +61,10 @@ spec:
                   None (skip post-restore cleanup, typical for a fresh hub),
                   CleanupAll (broader cleanup of ACM-scoped resources not in the current backup, including user-created; use with
                   caution).
+                enum:
+                - CleanupRestored
+                - None
+                - CleanupAll
                 type: string
               excludedNamespaces:
                 description: |-

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -2519,6 +2519,7 @@ var _ = Describe("Finalizer Cleanup Tests", func() {
 					VeleroManagedClustersBackupName: &skipBackup,
 					VeleroCredentialsBackupName:     &skipBackup,
 					VeleroResourcesBackupName:       &skipBackup,
+					CleanupBeforeRestore:            v1beta1.CleanupTypeNone,
 				},
 			}
 			Expect(k8sClient.Create(ctx, restore)).Should(Succeed())
@@ -2566,6 +2567,7 @@ var _ = Describe("Finalizer Cleanup Tests", func() {
 					VeleroManagedClustersBackupName: &skipBackup,
 					VeleroCredentialsBackupName:     &skipBackup,
 					VeleroResourcesBackupName:       &skipBackup,
+					CleanupBeforeRestore:            v1beta1.CleanupTypeNone,
 				},
 			}
 			Expect(k8sClient.Create(ctx, acmRestore)).Should(Succeed())
@@ -2696,6 +2698,7 @@ var _ = Describe("Finalizer Cleanup Tests", func() {
 					VeleroManagedClustersBackupName: &skipBackup,
 					VeleroCredentialsBackupName:     &skipBackup,
 					VeleroResourcesBackupName:       &skipBackup,
+					CleanupBeforeRestore:            v1beta1.CleanupTypeNone,
 				},
 			}
 			Expect(k8sClient.Create(ctx, acmRestore)).Should(Succeed())
@@ -2827,6 +2830,7 @@ var _ = Describe("Finalizer Cleanup Tests", func() {
 					VeleroManagedClustersBackupName: &skipBackup,
 					VeleroCredentialsBackupName:     &skipBackup,
 					VeleroResourcesBackupName:       &skipBackup,
+					CleanupBeforeRestore:            v1beta1.CleanupTypeNone,
 				},
 			}
 			Expect(k8sClient.Create(ctx, acmRestore)).Should(Succeed())
@@ -2954,6 +2958,7 @@ var _ = Describe("Finalizer Cleanup Tests", func() {
 					VeleroManagedClustersBackupName: &skipBackup,
 					VeleroCredentialsBackupName:     &skipBackup,
 					VeleroResourcesBackupName:       &skipBackup,
+					CleanupBeforeRestore:            v1beta1.CleanupTypeNone,
 				},
 			}
 			Expect(k8sClient.Create(ctx, acmRestore)).Should(Succeed())

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -365,6 +365,7 @@ var _ = Describe("BackupSchedule controller", func() {
 						VeleroManagedClustersBackupName: &skipBackup,
 						VeleroCredentialsBackupName:     &skipBackup,
 						VeleroResourcesBackupName:       &skipBackup,
+						CleanupBeforeRestore:            v1beta1.CleanupTypeNone,
 					},
 				}
 				Expect(k8sClient.Create(ctx, conflictingRestore)).Should(Succeed())

--- a/hack/augment-backupschedule-crd-descriptions.sh
+++ b/hack/augment-backupschedule-crd-descriptions.sh
@@ -13,11 +13,6 @@ import sys
 path = pathlib.Path(os.environ["AUGMENT_BACKUPSCHEDULE_CRD"])
 text = path.read_text()
 
-marker = "For ACM hub backups, increase this if CSI"
-if marker in text:
-    print(f"ACM Velero field descriptions already present in {path}, skipping")
-    sys.exit(0)
-
 replacements = [
     (
         """                          csiSnapshotTimeout:
@@ -67,16 +62,25 @@ replacements = [
     ),
 ]
 
+changed = False
 for old, new in replacements:
-    if old not in text:
-        print(
-            "augment-backupschedule-crd-descriptions: expected Velero block not found; "
-            "update hack/augment-backupschedule-crd-descriptions.sh if Velero CRD schema changed",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    text = text.replace(old, new)
+    if old in text:
+        text = text.replace(old, new)
+        changed = True
+        continue
+    if new in text:
+        # Already augmented for this block (idempotent per replacement).
+        continue
+    print(
+        "augment-backupschedule-crd-descriptions: expected Velero block not found; "
+        "update hack/augment-backupschedule-crd-descriptions.sh if Velero CRD schema changed",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 path.write_text(text)
-print(f"Updated {path}")
+if changed:
+    print(f"Updated {path}")
+else:
+    print(f"ACM Velero field descriptions already present in {path}, skipping")
 PY

--- a/hack/augment-backupschedule-crd-descriptions.sh
+++ b/hack/augment-backupschedule-crd-descriptions.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Re-applies ACM-specific descriptions to Velero Schedule template fields embedded in the
+# BackupSchedule CRD. controller-gen copies Velero's BackupSpec without ACM context; this
+# script runs after `make manifests` to restore those additions.
+set -euo pipefail
+CRD="${1:-config/crd/bases/cluster.open-cluster-management.io_backupschedules.yaml}"
+export AUGMENT_BACKUPSCHEDULE_CRD="$CRD"
+python3 <<'PY'
+import os
+import pathlib
+import sys
+
+path = pathlib.Path(os.environ["AUGMENT_BACKUPSCHEDULE_CRD"])
+text = path.read_text()
+
+marker = "For ACM hub backups, increase this if CSI"
+if marker in text:
+    print(f"ACM Velero field descriptions already present in {path}, skipping")
+    sys.exit(0)
+
+replacements = [
+    (
+        """                          csiSnapshotTimeout:
+                            description: |-
+                              CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                              ReadyToUse during creation, before returning error as timeout.
+                              The default value is 10 minute.
+                            type: string""",
+        """                          csiSnapshotTimeout:
+                            description: |-
+                              CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                              ReadyToUse during creation, before returning error as timeout.
+                              The default value is 10 minute.
+                              For ACM hub backups, increase this if CSI snapshot creation for hub PVCs (for example storage-backed
+                              volumes for hub components) is slow; otherwise keep the default unless Velero backup logs show CSI timeout errors.
+                            type: string""",
+    ),
+    (
+        """                          datamover:
+                            description: |-
+                              DataMover specifies the data mover to be used by the backup.
+                              If DataMover is "" or "velero", the built-in data mover will be used.
+                            type: string""",
+        """                          datamover:
+                            description: |-
+                              DataMover specifies the data mover to be used by the backup.
+                              If DataMover is "" or "velero", the built-in data mover will be used.
+                              For ACM hub backups, set or change this when your storage class requires the Velero node-agent data
+                              mover path instead of snapshots alone (for example large or non-snapshot volumes); leave empty for typical snapshot-based hub backups.
+                            type: string""",
+    ),
+    (
+        """                          defaultVolumesToFsBackup:
+                            description: |-
+                              DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                              for all volumes by default.
+                            nullable: true
+                            type: boolean""",
+        """                          defaultVolumesToFsBackup:
+                            description: |-
+                              DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                              for all volumes by default.
+                              For ACM hub backups, set to true when hub workloads use volumes that cannot use snapshots or when
+                              file-system backup is required for specific hub data; otherwise leave false/unset to prefer snapshot backup where supported.
+                            nullable: true
+                            type: boolean""",
+    ),
+]
+
+for old, new in replacements:
+    if old not in text:
+        print(
+            "augment-backupschedule-crd-descriptions: expected Velero block not found; "
+            "update hack/augment-backupschedule-crd-descriptions.sh if Velero CRD schema changed",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    text = text.replace(old, new)
+
+path.write_text(text)
+print(f"Updated {path}")
+PY


### PR DESCRIPTION
**Description**
Jira
[ACM-32727](https://issues.redhat.com/browse/ACM-32727) — improve OpenAPI / description fields on cluster-backup CRDs (grading rubric / API docs).

**Summary**
Expands kubebuilder comments and generated CRD schemas for BackupSchedule and Restore so status and spec fields are documented clearly, including when values are empty and which lifecycle phases apply.

**What changed**

_Restore_

- Document status.veleroManagedClustersRestoreName, veleroResourcesRestoreName, veleroGenericResourcesRestoreName, veleroCredentialsRestoreName: Velero Restore object referenced, when empty.
- status.phase: ACM restore phases; status.lastMessage: outcome / reason for current phase.
- spec.cleanupBeforeRestore: Post-restore hub cleanup (after Velero completes), with enum-style options including CleanupAll.


_BackupSchedule_

- spec.veleroSchedule: cron meaning + example (0 */2 * * *).
- spec.useOwnerReferencesInBackup: correct field name and GC behavior.
- status.phase / status.lastMessage: phases and validation/operation messaging.

_BackupSchedule CRD (embedded Velero template)_

- Extra guidance for csiSnapshotTimeout, datamover, defaultVolumesToFsBackup (ACM hub context; upstream embedded types do not carry this).

_Build / maintenance_

- hack/augment-backupschedule-crd-descriptions.sh: reapplies the Velero template description text after controller-gen (idempotent).
- Makefile: manifests runs the augment script after controller-gen so regenerating CRDs keeps the augmented descriptions.


**Testing**
make test (includes make manifests, lint, controller tests).



[ACM-32727]: https://redhat.atlassian.net/browse/ACM-32727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced BackupSchedule and Restore CRD descriptions with cron examples, clarified lifecycle phase enums, expanded cleanup semantics (including CleanupAll), and richer status/last-message guidance.
  * Improved ACM hub backup guidance for CSI timeouts, data-mover usage, and filesystem vs snapshot backup.
* **Chore**
  * Added automation to post-process generated CRD docs so BackupSchedule descriptions include ACM-specific guidance during manifest generation.
* **Tests**
  * Updated tests to explicitly set restore cleanup behavior in relevant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->