### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,52 @@
+ARG ACM_VERSION="unknown"
+
+# Build the manager binary
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+ENV GOEXPERIMENT=strictfipsruntime
+ENV BUILD_TAGS="strictfipsruntime"
+
+WORKDIR /workspace
+# Copy the source files
+COPY main.go main.go
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY api/. api/
+COPY config/. config/
+COPY controllers/ controllers/
+
+# Copy the go source
+RUN  CGO_ENABLED=1 GOFLAGS='-mod=readonly' go mod vendor
+# RUN  CGO_ENABLED=1 GOFLAGS='-mod=readonly' GOOS=linux GOARCH=amd64 go mod tidy
+
+# Build
+RUN CGO_ENABLED=1 GOFLAGS='-mod=readonly' go build -tags strictfipsruntime -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG ACM_VERSION
+
+LABEL \
+    name="rhacm2/cluster-backup-rhel9-operator" \
+    cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9" \
+    com.redhat.component="cluster-backup-operator" \
+    description="The Cluster Backup and Restore Operator runs on the hub cluster, providing disaster recovery \
+    solutions for Red Hat Advanced Cluster Management in the event of hub cluster failures." \
+    io.k8s.description="The Cluster Backup and Restore Operator runs on the hub cluster, providing disaster recovery \
+    solutions for Red Hat Advanced Cluster Management in the event of hub cluster failures." \
+    summary="An ACM operator that delivers disaster recovery solutions for hub cluster failures." \
+    io.k8s.display-name="Red Hat Advanced Cluster Management Cluster Backup and Restore Operator" \
+    io.openshift.tags="acm cluster-backup-operator" \
+    url="https://github.com/stolostron/cluster-backup-operator"
+WORKDIR /
+COPY --from=builder /workspace/manager .
+
+# License
+RUN mkdir licenses/
+COPY LICENSE licenses/
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)