### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md — cluster-backup-operator
+
+AI assistant context for the **Cluster Backup and Restore Operator** — an ACM hub operator that drives Velero to back up and restore Open Cluster Management hub resources.
+
+---
+
+## Build, Test, and Lint Commands
+
+```bash
+# Generate CRDs, RBAC manifests, and DeepCopy code
+make manifests generate
+
+# Format and vet
+make fmt
+make vet
+
+# Build the manager binary (runs generate + fmt + vet first)
+make build
+
+# Run tests (runs manifests + generate + fmt + vet first, downloads envtest)
+make test
+
+# Run controller locally against the current kubeconfig
+make run
+
+# Install CRDs into the cluster
+make install
+
+# Deploy controller into the cluster (set IMG first)
+make deploy IMG=<registry>/<image>:<tag>
+
+# Build container image
+make docker-build IMG=<registry>/<image>:<tag>
+```
+
+> Tests use `controller-runtime`'s envtest harness. `testbin/` is populated automatically on first `make test`.
+
+---
+
+## Repo Layout
+
+```
+api/v1beta1/          CRD type definitions (Backup, Restore)
+controllers/          Reconciler implementations and helpers
+  backup_controller.go   BackupReconciler — drives Velero Backup CRs
+  restore_controller.go  RestoreReconciler — drives Velero Restore CRs
+  backup.go              Backup helper functions
+  restore.go             Restore helper functions
+config/               Kustomize manifests (CRDs, RBAC, manager, samples)
+config/samples/       Example Backup and Restore CRs
+hack/                 Boilerplate and tooling scripts
+testbin/              Downloaded envtest binaries (git-ignored)
+bin/                  Downloaded tooling (controller-gen, kustomize)
+```
+
+---
+
+## Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a full description of the CRDs, Velero schedule strategy, backup selection logic, passive vs. activation data categories, controller reconciliation flow, and disaster-recovery patterns.
+
+---
+
+## Personal Config
+
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders. Run `make personalize` to generate it (if this repo uses Fleet Engineering tooling).
+
+---
+
+## Fleet Engineering Skills
+
+| Skill | Purpose | Path |
+|---|---|---|
+| `bug-specialist` | Bug triage, reproduction steps, fix planning | `skills/jira/bug-specialist/` |
+| `epic-specialist` | Multi-sprint epics with outcomes | `skills/jira/epic-specialist/` |
+| `feature-specialist` | Large customer-facing capabilities | `skills/jira/feature-specialist/` |
+| `initiative-specialist` | Multi-team strategic programs | `skills/jira/initiative-specialist/` |
+| `jira-create` | Interactive issue creation with specialist delegation | `skills/jira/jira-create/` |
+| `jira-specialist` | General triage, search, linking, transitions | `skills/jira/jira-specialist/` |
+| `outcome-specialist` | Strategic outcomes tied to OKRs | `skills/jira/outcome-specialist/` |
+| `spike-specialist` | Time-boxed research and PoC | `skills/jira/spike-specialist/` |
+| `story-specialist` | User stories with acceptance criteria | `skills/jira/story-specialist/` |
+| `task-specialist` | Internal technical tasks | `skills/jira/task-specialist/` |
+| `agent-memory-setup` | Initialize or update CLAUDE.md / AGENTS.md | `skills/sdlc/agent-memory-setup/` |
+| `finish-work` | Commit, push, open PR, update Jira | `skills/sdlc/finish-work/` |
+| `pr-fix` | Fix blocked PRs: merge conflicts, CI failures, review comments | `skills/sdlc/pr-fix/` |
+| `pr-review` | GitHub PR review with inline comments | `skills/sdlc/pr-review/` |
+| `start-work` | Create a Jira sub-task for the current work session | `skills/sdlc/start-work/` |
+| `f2f-daily-summary` | Capture daily F2F meeting notes as Jira sub-tasks | `skills/meetings/f2f-daily-summary/` |
+| `f2f-epic-specialist` | Create and manage F2F meeting Epics | `skills/meetings/f2f-epic-specialist/` |
+| `presentation-task` | Log a delivered presentation as a closed Jira sub-task | `skills/meetings/presentation-task/` |
+
+Skills live in the shared [`agentic-sdlc`](https://github.com/sahare/agentic-sdlc) repository. Read the relevant `SKILL.md` before executing any multi-step workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ make docker-build IMG=<registry>/<image>:<tag>
 ```
 
 > Tests use `controller-runtime`'s envtest harness. `testbin/` is populated automatically on first `make test`.
+>
+> ⚠️ **Go version compatibility:** This repo targets Go 1.16. The pinned `controller-gen` version is incompatible with Go 1.24+. Running `make generate` or `make test` on a newer Go install will fail. Either use Go 1.16–1.23, or update `go.mod` and the `controller-gen` version pin in the Makefile first.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 AI assistant context for the **Cluster Backup and Restore Operator** — an ACM hub operator that drives Velero to back up and restore Open Cluster Management hub resources.
 
+This file follows the Fleet Engineering [repo-onboarding practice](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md). Day-to-day workflow: [ai-dev-workflow.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/ai-dev-workflow.md).
+
 ---
 
 ## Build, Test, and Lint Commands
@@ -41,7 +43,7 @@ make docker-build IMG=<registry>/<image>:<tag>
 
 ## Repo Layout
 
-```
+```text
 api/v1beta1/          CRD type definitions (Backup, Restore)
 controllers/          Reconciler implementations and helpers
   backup_controller.go   BackupReconciler — drives Velero Backup CRs
@@ -65,13 +67,13 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a full description of the C
 
 ## Personal Config
 
-Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders. Run `make personalize` to generate it (if this repo uses Fleet Engineering tooling).
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders. Run `make personalize` from the [agentic-sdlc](https://github.com/OpenShift-Fleet/agentic-sdlc) repo to generate it.
 
 ---
 
 ## Fleet Engineering Skills
 
-Fetch and apply the relevant skill when the task matches its domain.
+If the Fleet Engineering plugin is installed (`claude plugin list` shows `ocp-fleet-agentic-sdlc`), use slash commands directly (e.g. `/start-work`). Otherwise fetch and apply skills via the URLs below.
 
 | Skill | When to use |
 |---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,25 +69,15 @@ Read `.claude/user.local.md` at the start of any task that needs an assignee, em
 
 ## Fleet Engineering Skills
 
-| Skill | Purpose | Path |
-|---|---|---|
-| `bug-specialist` | Bug triage, reproduction steps, fix planning | `skills/jira/bug-specialist/` |
-| `epic-specialist` | Multi-sprint epics with outcomes | `skills/jira/epic-specialist/` |
-| `feature-specialist` | Large customer-facing capabilities | `skills/jira/feature-specialist/` |
-| `initiative-specialist` | Multi-team strategic programs | `skills/jira/initiative-specialist/` |
-| `jira-create` | Interactive issue creation with specialist delegation | `skills/jira/jira-create/` |
-| `jira-specialist` | General triage, search, linking, transitions | `skills/jira/jira-specialist/` |
-| `outcome-specialist` | Strategic outcomes tied to OKRs | `skills/jira/outcome-specialist/` |
-| `spike-specialist` | Time-boxed research and PoC | `skills/jira/spike-specialist/` |
-| `story-specialist` | User stories with acceptance criteria | `skills/jira/story-specialist/` |
-| `task-specialist` | Internal technical tasks | `skills/jira/task-specialist/` |
-| `agent-memory-setup` | Initialize or update CLAUDE.md / AGENTS.md | `skills/sdlc/agent-memory-setup/` |
-| `finish-work` | Commit, push, open PR, update Jira | `skills/sdlc/finish-work/` |
-| `pr-fix` | Fix blocked PRs: merge conflicts, CI failures, review comments | `skills/sdlc/pr-fix/` |
-| `pr-review` | GitHub PR review with inline comments | `skills/sdlc/pr-review/` |
-| `start-work` | Create a Jira sub-task for the current work session | `skills/sdlc/start-work/` |
-| `f2f-daily-summary` | Capture daily F2F meeting notes as Jira sub-tasks | `skills/meetings/f2f-daily-summary/` |
-| `f2f-epic-specialist` | Create and manage F2F meeting Epics | `skills/meetings/f2f-epic-specialist/` |
-| `presentation-task` | Log a delivered presentation as a closed Jira sub-task | `skills/meetings/presentation-task/` |
+Fetch and apply the relevant skill when the task matches its domain.
 
-Skills live in the shared [`agentic-sdlc`](https://github.com/sahare/agentic-sdlc) repository. Read the relevant `SKILL.md` before executing any multi-step workflow.
+| Skill | When to use |
+|---|---|
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Begin work on a Jira ticket — creates sub-task, transitions status |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | Review a GitHub PR with worktree isolation and inline comments |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | Triage, search, link, or transition Jira issues |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Create a well-structured bug report with reproduction steps |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | Create a user story with acceptance criteria |
+| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC tickets |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,153 @@
+# Architecture — Cluster Backup and Restore Operator
+
+The **Cluster Backup and Restore Operator** runs on an ACM hub cluster and automates the backup and restore of hub resources using [Velero](https://velero.io/) (installed via the [OADP Operator](https://github.com/openshift/oadp-operator)).
+
+---
+
+## CRDs
+
+### `Backup` (`cluster.open-cluster-management.io/v1beta1`)
+
+Short name: `cbkp`
+
+| Field | Purpose |
+|---|---|
+| `spec.veleroConfigBackupProxy.metadata` | Namespace where OADP/Velero is installed |
+| `spec.interval` | Minutes to wait after backup completion before starting the next |
+| `spec.maxBackups` | Maximum number of Velero Backup CRs to retain (oldest deleted first, errors first) |
+
+Status tracks `phase`, `currentBackup`, `lastBackup`, `completionTimestamp`, `backupDuration`, and the full `veleroBackup` object.
+
+### `Restore` (`cluster.open-cluster-management.io/v1beta1`)
+
+Short name: `crst`
+
+| Field | Purpose |
+|---|---|
+| `spec.backupName` | Name of the `velero.io/Backup` to restore |
+| `spec.veleroConfigRestoreProxy.metadata` | Namespace where OADP/Velero is installed |
+| `spec.veleroConfigRestoreProxy.detachManagedClusters` | If true, detach managed clusters from the backed-up hub before restoring |
+| `spec.veleroConfigRestoreProxy.BackedUpHubSecretName` | Secret to access the backed-up hub during cluster detachment |
+
+Status tracks `phase`, `lastMessage`, and the full `veleroRestore` object.
+
+---
+
+## Velero Schedules
+
+The operator creates **5 Velero Schedule CRs** in the `open-cluster-management-backup` namespace, organised by data category:
+
+| Schedule Name | Data Category | Contents |
+|---|---|---|
+| `acm-credentials-schedule` | Passive | ACM credentials and secrets |
+| `acm-resources-schedule` | Passive | Core ACM hub resources |
+| `acm-resources-generic-schedule` | Passive | Generic/app resources not covered above |
+| `acm-managed-clusters-schedule` | **Activation** | Managed cluster activation data |
+| `acm-validation-policy-schedule` | Passive | Validation policies |
+
+### Data Categories
+
+**Passive data** (credentials, resources, apps) can be restored to a passive standby hub. Restoring passive data alone does **not** reconnect managed clusters to the new hub; the original hub remains active.
+
+**Activation data** (`acm-managed-clusters-schedule`) contains the managed-cluster resources needed to re-register clusters. Restoring this schedule on the new hub reconnects all managed clusters, making the new hub active. This is the final step in a DR failover.
+
+---
+
+## Backup Selection
+
+### Included by Default
+
+Resources whose API group matches any of:
+
+- `*.open-cluster-management.io`
+- `*.hive.openshift.io`
+- `argoproj.io`
+- `app.k8s.io`
+
+Namespaces included:
+
+- `open-cluster-management-agent`
+- `open-cluster-management-hub`
+- `hive`
+- `openshift-operator-lifecycle-manager`
+- `open-cluster-management-observability`
+- All app Channel namespaces (excluding `open-cluster-management/charts-v1`)
+- All ManagedCluster namespaces (excluding `local-cluster`)
+
+### Excluded by Default
+
+Resources whose API group matches:
+
+- `internal.*`
+- `operator.*`
+- `work.*`
+- `search.*`
+- `velero.io`
+
+### Including Custom Resources
+
+To include a custom resource in backups, add the label:
+
+```yaml
+cluster.open-cluster-management.io/backup: ""
+```
+
+---
+
+## Controller Flow
+
+### BackupReconciler
+
+1. Reconcile loop triggered by `Backup` CR changes; requeues every 1 minute.
+2. Calls `getActiveBackupName` — returns existing in-progress backup name, or generates a new timestamped name.
+3. If the Velero Backup CR does not exist:
+   - Calls `canStartBackup` to check the interval since last completion.
+   - Calls `cleanupBackups` to delete oldest backups exceeding `maxBackups` (error-status backups deleted first).
+   - Calls `setBackupInfo` to populate included namespaces (ACM, observability, channels, managed clusters).
+   - Creates the Velero `Backup` CR.
+4. If the Velero Backup CR exists: reads phase/progress and updates `Backup.Status`.
+5. Updates `Backup.Status` via `Status().Update`.
+
+### RestoreReconciler
+
+1. Reconcile loop triggered by `Restore` CR changes; requeues every 1 minute until finished.
+2. Calls `getVeleroRestoreName` to derive the Velero Restore name (`<restore-name>-<backup-name>`).
+3. If the Velero Restore CR does not exist: sets `spec.backupName` and creates it.
+4. If the Velero Restore CR exists: reads phase and updates `Restore.Status`.
+5. When restore reaches a terminal phase (`Completed`, `Failed`, `PartiallyFailed`, `FailedValidation`), stops requeuing.
+
+---
+
+## Namespace Layout
+
+| Namespace | Contents |
+|---|---|
+| `open-cluster-management-backup` | Velero Schedules, Backup CRs, Restore CRs created by this operator |
+| `open-cluster-management` | ACM hub components (backed up, not operator home) |
+| `open-cluster-management-agent` | Agent resources (backed up) |
+| `open-cluster-management-hub` | Hub resources (backed up) |
+| `hive` | Hive resources (backed up) |
+| OADP namespace (configurable) | Velero deployment, `BackupStorageLocation` |
+
+---
+
+## Active/Passive Disaster Recovery
+
+For active/passive hub DR, set `syncRestoreWithNewBackups: true` on the `Restore` CR. The restore controller will continuously sync the passive hub with the latest backup, keeping it warm. When failover is needed:
+
+1. Restore passive data schedules on the new hub (hub is passive, clusters stay connected to old hub).
+2. Restore activation data (`acm-managed-clusters-schedule`) to reconnect managed clusters to the new hub.
+
+**Collision detection:** If the same resource exists on both hubs simultaneously (split-brain), the operator emits a warning event. Operators should resolve collisions before completing the failover.
+
+---
+
+## Dependencies
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `sigs.k8s.io/controller-runtime` | v0.8.3 | Operator framework |
+| `github.com/vmware-tanzu/velero` | v1.6.1 | Backup/restore engine |
+| `github.com/open-cluster-management/api` | v0.0.0-20210527 | ManagedCluster types |
+| `github.com/open-cluster-management/multicloud-operators-channel` | v1.2.2 | Channel types for app namespace discovery |
+| `k8s.io/api`, `k8s.io/apimachinery` | v0.20.2 | Kubernetes core types |


### PR DESCRIPTION
Onboards **cluster-backup-operator** to the Fleet Engineering Agentic SDLC per [repo-onboarding.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md).

- Restructures `CLAUDE.md` with verified build/test/lint commands, repo layout, links to `repo-onboarding.md` and `ai-dev-workflow.md`, personal config lookup (`make personalize`), and Fleet Engineering skills catalog (URL fallback for Cursor / agents without the plugin)
- Adds `docs/ARCHITECTURE.md` covering both CRDs (`Backup`, `Restore`), the 5 Velero schedules, passive vs. activation data categories, backup selection rules, controller reconciliation flow, namespace layout, and active/passive DR patterns

## Onboarding checklist

Per [repo-onboarding.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md):

- [x] `CLAUDE.md` — build/lint/test commands verified against root `Makefile`
- [x] Personal config lookup with `make personalize` reference
- [x] `docs/ARCHITECTURE.md` created and linked
- [x] Link to `repo-onboarding.md` and `ai-dev-workflow.md` in `CLAUDE.md`
- [x] Fleet Engineering skills URL table (for non-plugin environments)
- [x] Fleet plugin vs URL fallback clarified
- [ ] `make personalize` / `make install-claude` — operator setup (outside this PR)
- [ ] First `/start-work` session — post-merge validation

## Test plan

- Docs-only change — no code or CI target changes
- `CLAUDE.md` repo-layout fence uses `text` language tag (MD040)
- Spot-check `make` targets against root `Makefile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added developer docs with build/test/lint and install/run/deploy commands, plus guidance for per-task personal config and fallback behavior
  * Added detailed architecture docs for the Cluster Backup and Restore Operator: CRDs, controller flows, schedules, namespace/layout, active/passive DR behavior, and collision warnings
  * Documented Go toolchain compatibility constraints affecting generate/test workflows
  * Added a Fleet Engineering skills & workflow reference (Jira/PR guidance)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->