### PR TITLE
chore: bump Go to 1.26 for CVE-2026-27145 [release-2.16]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # Copy the source files

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,7 +1,7 @@
 ARG ACM_VERSION="unknown"
 
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV BUILD_TAGS="strictfipsruntime"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 VERSION ?= 0.0.1
 
 # Helper software versions
-GOLANGCI_VERSION := v2.7.2
+GOLANGCI_VERSION := v2.9.0
 CONTROLLER_TOOLS_VERSION := v0.17.3
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
@@ -139,7 +139,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 .PHONY: golangci-lint
 GOLANGCILINT := $(LOCALBIN)/golangci-lint
-GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh
 golangci-lint: $(GOLANGCILINT) ## Download golangci-lint
 $(GOLANGCILINT): $(LOCALBIN)
 	test -s $@ || { curl -sSfL $(GOLANGCI_URL) | sh -s -- -b $(LOCALBIN) $(GOLANGCI_VERSION); }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/cluster-backup-operator
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Update go.mod, Dockerfile, Dockerfile.rhtap, and golangci-lint to Go 1.26. Required to fix CVE-2026-27145 (crypto/x509 DoS) — no fix available for Go 1.25 builders.

Jira: https://redhat.atlassian.net/browse/ACM-37768

Made with [Cursor](https://cursor.com)