### PR TITLE
fix: use golangci-lint main branch for install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 .PHONY: golangci-lint
 GOLANGCILINT := $(LOCALBIN)/golangci-lint
-GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh
 golangci-lint: $(GOLANGCILINT) ## Download golangci-lint
 $(GOLANGCILINT): $(LOCALBIN)
 	test -s $@ || { curl -sSfL $(GOLANGCI_URL) | sh -s -- -b $(LOCALBIN) $(GOLANGCI_VERSION); }


### PR DESCRIPTION
The golangci-lint master branch is deprecated. Switch to main to prevent install failures.

Jira: https://redhat.atlassian.net/browse/ACM-37371

Made with [Cursor](https://cursor.com)