### PR TITLE
fix: auto-label secrets/configmaps referenced by ClusterDeployment

### DIFF
--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -92,7 +92,17 @@ const (
         ]
     }`
 
-	update_msg = "Updated secret %s in ns %s"
+	update_msg    = "Updated secret %s in ns %s"
+	update_cm_msg = "Updated configmap %s in ns %s"
+
+	// label values for secrets/configmaps referenced by name on a ClusterDeployment
+	// we already back up. Unlike other user-provided Hive data, these references are
+	// discoverable directly off the ClusterDeployment spec, so they don't require the
+	// user to label them manually.
+	certificate_bundle_label_value  = "certificatebundle"
+	pull_secret_label_value         = "pullsecret"
+	manifests_secret_label_value    = "manifestssecret"
+	manifests_configmap_label_value = "manifestsconfigmap"
 )
 
 // isMSAComponentEnabled checks if the managedserviceaccount component is enabled in MCE
@@ -887,6 +897,11 @@ func updateHiveResources(ctx context.Context,
 	if err := c.List(ctx, clusterDeployments, &client.ListOptions{}); err == nil {
 		for i := range clusterDeployments.Items {
 			clusterDeployment := clusterDeployments.Items[i]
+
+			// label secrets/configmaps this ClusterDeployment explicitly references
+			// by name, regardless of whether it originated from a ClusterPool
+			updateHiveReferencedSecrets(ctx, c, clusterDeployment)
+
 			if clusterDeployment.Spec.ClusterPoolRef != nil {
 				secrets := &corev1.SecretList{}
 				if err := c.List(ctx, secrets, &client.ListOptions{
@@ -934,6 +949,117 @@ func updateHiveResources(ctx context.Context,
 			}
 		}
 	}
+}
+
+// updateHiveReferencedSecrets adds the backup label to secrets and configmaps that a
+// ClusterDeployment explicitly references by name: CertificateBundles, PullSecretRef,
+// and the Provisioning ManifestsSecretRef/ManifestsConfigMapRef. These are distinct from
+// other user-provided Hive data (e.g. InstallConfigSecretRef): the reference is read
+// directly off a resource the operator already backs up, so the secret/configmap
+// identity is discoverable without relying on the user to label it manually.
+//
+// BoundServiceAccountSigningKeySecretRef is deliberately NOT included here even though
+// it fits the same discoverability pattern: it references private key material (used to
+// sign ServiceAccount tokens for AWS STS), which carries a different risk profile than a
+// cert bundle or manifest override secret. Left as an open question pending team input
+// (ACM-38831).
+func updateHiveReferencedSecrets(ctx context.Context,
+	c client.Client,
+	clusterDeployment hivev1.ClusterDeployment,
+) {
+	for i := range clusterDeployment.Spec.CertificateBundles {
+		labelSecretByName(ctx, c, clusterDeployment.Namespace,
+			clusterDeployment.Spec.CertificateBundles[i].CertificateSecretRef.Name,
+			certificate_bundle_label_value)
+	}
+
+	if ref := clusterDeployment.Spec.PullSecretRef; ref != nil {
+		labelSecretByName(ctx, c, clusterDeployment.Namespace, ref.Name, pull_secret_label_value)
+	}
+
+	provisioning := clusterDeployment.Spec.Provisioning
+	if provisioning == nil {
+		return
+	}
+
+	if ref := provisioning.ManifestsSecretRef; ref != nil {
+		labelSecretByName(ctx, c, clusterDeployment.Namespace, ref.Name, manifests_secret_label_value)
+	}
+
+	if ref := provisioning.ManifestsConfigMapRef; ref != nil {
+		labelConfigMapByName(ctx, c, clusterDeployment.Namespace, ref.Name, manifests_configmap_label_value)
+	}
+}
+
+// labelSecretByName fetches the named secret and adds the cluster backup label to it,
+// if it doesn't already carry one of the recognized backup labels.
+func labelSecretByName(ctx context.Context,
+	c client.Client,
+	namespace string,
+	name string,
+	labelValue string,
+) {
+	if name == "" {
+		return
+	}
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
+		// secret not found, or referenced from a different namespace; nothing to label
+		return
+	}
+	updateSecret(ctx, c, *secret, backupCredsClusterLabel, labelValue, true)
+}
+
+// labelConfigMapByName fetches the named configmap and adds the cluster backup label to
+// it, if it doesn't already carry one of the recognized backup labels.
+func labelConfigMapByName(ctx context.Context,
+	c client.Client,
+	namespace string,
+	name string,
+	labelValue string,
+) {
+	if name == "" {
+		return
+	}
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm); err != nil {
+		// configmap not found, or referenced from a different namespace; nothing to label
+		return
+	}
+	updateConfigMap(ctx, c, *cm, backupCredsClusterLabel, labelValue, true)
+}
+
+// updateConfigMap adds the backup label to a configmap, mirroring updateSecret's
+// behavior for secrets: it only sets the label if none of the recognized backup
+// labels are already present.
+func updateConfigMap(ctx context.Context,
+	c client.Client,
+	cm corev1.ConfigMap,
+	labelName string,
+	labelValue string,
+	update bool,
+) bool {
+	logger := log.FromContext(ctx)
+	labels := cm.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if labels[backupCredsHiveLabel] == "" &&
+		labels[backupCredsUserLabel] == "" &&
+		labels[backupCredsClusterLabel] == "" {
+		labels[labelName] = labelValue
+		cm.SetLabels(labels)
+		msg := "update configmap " + cm.Name
+		logger.Info(msg)
+		if !update {
+			return true
+		}
+		if err := c.Update(ctx, &cm, &client.UpdateOptions{}); err == nil {
+			logger.Info(fmt.Sprintf(update_cm_msg, cm.Name, cm.Namespace))
+		}
+		return true
+	}
+	return false
 }
 
 // prepare AutomatedInstaller resources

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -928,6 +928,11 @@ func updateHiveResources(ctx context.Context,
 	clusterPools := &hivev1.ClusterPoolList{}
 	if err := c.List(ctx, clusterPools, &client.ListOptions{}); err == nil {
 		for i := range clusterPools.Items {
+			if localClusterName != "" && clusterPools.Items[i].Namespace == localClusterName {
+				// skip local-cluster: restoring these resources would corrupt the target hub
+				continue
+			}
+
 			secrets := &corev1.SecretList{}
 			if err := c.List(ctx, secrets, &client.ListOptions{
 				Namespace: clusterPools.Items[i].Namespace,

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -92,17 +92,16 @@ const (
         ]
     }`
 
-	update_msg    = "Updated secret %s in ns %s"
-	update_cm_msg = "Updated configmap %s in ns %s"
+	update_msg = "Updated secret %s in ns %s"
 
 	// label values for secrets/configmaps referenced by name on a ClusterDeployment
 	// we already back up. Unlike other user-provided Hive data, these references are
 	// discoverable directly off the ClusterDeployment spec, so they don't require the
 	// user to label them manually.
-	certificate_bundle_label_value  = "certificatebundle"
-	pull_secret_label_value         = "pullsecret"
-	manifests_secret_label_value    = "manifestssecret"
-	manifests_configmap_label_value = "manifestsconfigmap"
+	certificateBundleLabelValue  = "certificatebundle"
+	pullSecretLabelValue         = "pullsecret"
+	manifestsSecretLabelValue    = "manifestssecret"
+	manifestsConfigMapLabelValue = "manifestsconfigmap"
 )
 
 // isMSAComponentEnabled checks if the managedserviceaccount component is enabled in MCE
@@ -892,45 +891,32 @@ func updateHiveResources(ctx context.Context,
 	dr dynamic.NamespaceableResourceInterface,
 ) {
 	logger := log.FromContext(ctx)
+
+	// local-cluster is intentionally excluded from backup: restoring its resources
+	// would corrupt the target hub. Resolved dynamically since the local-cluster's
+	// namespace name is not guaranteed to be literally "local-cluster".
+	localClusterName, err := getLocalClusterName(ctx, c)
+	if err != nil {
+		logger.Error(err, "updateHiveResources: error looking up local-cluster name")
+	}
+
 	// update secrets for clusterDeployments created by cluster claims
 	clusterDeployments := &hivev1.ClusterDeploymentList{}
 	if err := c.List(ctx, clusterDeployments, &client.ListOptions{}); err == nil {
 		for i := range clusterDeployments.Items {
 			clusterDeployment := clusterDeployments.Items[i]
 
+			if localClusterName != "" && clusterDeployment.Namespace == localClusterName {
+				// skip local-cluster: restoring these resources would corrupt the target hub
+				continue
+			}
+
 			// label secrets/configmaps this ClusterDeployment explicitly references
 			// by name, regardless of whether it originated from a ClusterPool
 			updateHiveReferencedSecrets(ctx, c, clusterDeployment)
 
 			if clusterDeployment.Spec.ClusterPoolRef != nil {
-				secrets := &corev1.SecretList{}
-				if err := c.List(ctx, secrets, &client.ListOptions{
-					Namespace: clusterDeployment.Namespace,
-				}); err == nil {
-					// add backup labels if not set yet
-					updateSecretsLabels(ctx, c, *secrets, clusterDeployment.Name,
-						backupCredsClusterLabel,
-						"clusterpool")
-				}
-
-				// add a label annnotation to the resource
-				// to disable the creation webhook validation
-				// which doesn't allow restoring the ClusterDeployment
-				labels := clusterDeployment.GetLabels()
-				if labels == nil {
-					labels = make(map[string]string)
-				}
-				if labels[hive_label] != "" {
-					// label already set
-					continue
-				}
-				logger.Info("Patching disable-creation-webhook-for-dr label on deployment " + clusterDeployment.Name)
-
-				patch := `[ { "op": "add", "path": "` + hive_label_path + `", "value": "true" } ]`
-				if _, err := dr.Namespace(clusterDeployment.GetNamespace()).Patch(ctx, clusterDeployment.GetName(),
-					types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
-					logger.Error(err, "cannot patch with hive label hive.openshift.io~1disable-creation-webhook-for-dr")
-				}
+				prepareClusterPoolDeployment(ctx, c, dr, clusterDeployment)
 			}
 		}
 	}
@@ -948,6 +934,47 @@ func updateHiveResources(ctx context.Context,
 					"clusterpool")
 			}
 		}
+	}
+}
+
+// prepareClusterPoolDeployment labels the secrets in a ClusterPool-derived
+// ClusterDeployment's namespace and patches the disable-creation-webhook-for-dr label,
+// so the ClusterDeployment can be restored later without hitting Hive's creation
+// webhook validation.
+func prepareClusterPoolDeployment(ctx context.Context,
+	c client.Client,
+	dr dynamic.NamespaceableResourceInterface,
+	clusterDeployment hivev1.ClusterDeployment,
+) {
+	logger := log.FromContext(ctx)
+
+	secrets := &corev1.SecretList{}
+	if err := c.List(ctx, secrets, &client.ListOptions{
+		Namespace: clusterDeployment.Namespace,
+	}); err == nil {
+		// add backup labels if not set yet
+		updateSecretsLabels(ctx, c, *secrets, clusterDeployment.Name,
+			backupCredsClusterLabel,
+			"clusterpool")
+	}
+
+	// add a label annnotation to the resource
+	// to disable the creation webhook validation
+	// which doesn't allow restoring the ClusterDeployment
+	labels := clusterDeployment.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if labels[hive_label] != "" {
+		// label already set
+		return
+	}
+	logger.Info("Patching disable-creation-webhook-for-dr label on deployment " + clusterDeployment.Name)
+
+	patch := `[ { "op": "add", "path": "` + hive_label_path + `", "value": "true" } ]`
+	if _, err := dr.Namespace(clusterDeployment.GetNamespace()).Patch(ctx, clusterDeployment.GetName(),
+		types.JSONPatchType, []byte(patch), v1.PatchOptions{}); err != nil {
+		logger.Error(err, "cannot patch with hive label hive.openshift.io~1disable-creation-webhook-for-dr")
 	}
 }
 
@@ -970,11 +997,11 @@ func updateHiveReferencedSecrets(ctx context.Context,
 	for i := range clusterDeployment.Spec.CertificateBundles {
 		labelSecretByName(ctx, c, clusterDeployment.Namespace,
 			clusterDeployment.Spec.CertificateBundles[i].CertificateSecretRef.Name,
-			certificate_bundle_label_value)
+			certificateBundleLabelValue)
 	}
 
 	if ref := clusterDeployment.Spec.PullSecretRef; ref != nil {
-		labelSecretByName(ctx, c, clusterDeployment.Namespace, ref.Name, pull_secret_label_value)
+		labelSecretByName(ctx, c, clusterDeployment.Namespace, ref.Name, pullSecretLabelValue)
 	}
 
 	provisioning := clusterDeployment.Spec.Provisioning
@@ -983,16 +1010,18 @@ func updateHiveReferencedSecrets(ctx context.Context,
 	}
 
 	if ref := provisioning.ManifestsSecretRef; ref != nil {
-		labelSecretByName(ctx, c, clusterDeployment.Namespace, ref.Name, manifests_secret_label_value)
+		labelSecretByName(ctx, c, clusterDeployment.Namespace, ref.Name, manifestsSecretLabelValue)
 	}
 
 	if ref := provisioning.ManifestsConfigMapRef; ref != nil {
-		labelConfigMapByName(ctx, c, clusterDeployment.Namespace, ref.Name, manifests_configmap_label_value)
+		labelConfigMapByName(ctx, c, clusterDeployment.Namespace, ref.Name, manifestsConfigMapLabelValue)
 	}
 }
 
 // labelSecretByName fetches the named secret and adds the cluster backup label to it,
-// if it doesn't already carry one of the recognized backup labels.
+// if it doesn't already carry one of the recognized backup labels. Only a NotFound
+// error is treated as skippable; other errors (transient API failures, RBAC denials)
+// are logged as warnings so a labeling gap isn't entirely silent.
 func labelSecretByName(ctx context.Context,
 	c client.Client,
 	namespace string,
@@ -1004,14 +1033,19 @@ func labelSecretByName(ctx context.Context,
 	}
 	secret := &corev1.Secret{}
 	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
-		// secret not found, or referenced from a different namespace; nothing to label
+		if !k8serr.IsNotFound(err) {
+			log.FromContext(ctx).Error(err, "labelSecretByName: error getting referenced secret",
+				"name", name, "namespace", namespace)
+		}
 		return
 	}
 	updateSecret(ctx, c, *secret, backupCredsClusterLabel, labelValue, true)
 }
 
 // labelConfigMapByName fetches the named configmap and adds the cluster backup label to
-// it, if it doesn't already carry one of the recognized backup labels.
+// it, if it doesn't already carry one of the recognized backup labels. Only a NotFound
+// error is treated as skippable; other errors are logged as warnings so a labeling gap
+// isn't entirely silent.
 func labelConfigMapByName(ctx context.Context,
 	c client.Client,
 	namespace string,
@@ -1023,7 +1057,10 @@ func labelConfigMapByName(ctx context.Context,
 	}
 	cm := &corev1.ConfigMap{}
 	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm); err != nil {
-		// configmap not found, or referenced from a different namespace; nothing to label
+		if !k8serr.IsNotFound(err) {
+			log.FromContext(ctx).Error(err, "labelConfigMapByName: error getting referenced configmap",
+				"name", name, "namespace", namespace)
+		}
 		return
 	}
 	updateConfigMap(ctx, c, *cm, backupCredsClusterLabel, labelValue, true)
@@ -1049,13 +1086,14 @@ func updateConfigMap(ctx context.Context,
 		labels[backupCredsClusterLabel] == "" {
 		labels[labelName] = labelValue
 		cm.SetLabels(labels)
-		msg := "update configmap " + cm.Name
-		logger.Info(msg)
+		logger.Info("Updating configmap", "name", cm.Name, "namespace", cm.Namespace)
 		if !update {
 			return true
 		}
-		if err := c.Update(ctx, &cm, &client.UpdateOptions{}); err == nil {
-			logger.Info(fmt.Sprintf(update_cm_msg, cm.Name, cm.Namespace))
+		if err := c.Update(ctx, &cm, &client.UpdateOptions{}); err != nil {
+			logger.Error(err, "updateConfigMap: error updating configmap", "name", cm.Name, "namespace", cm.Namespace)
+		} else {
+			logger.Info("Updated configmap", "name", cm.Name, "namespace", cm.Namespace)
 		}
 		return true
 	}

--- a/controllers/pre_backup.go
+++ b/controllers/pre_backup.go
@@ -894,10 +894,13 @@ func updateHiveResources(ctx context.Context,
 
 	// local-cluster is intentionally excluded from backup: restoring its resources
 	// would corrupt the target hub. Resolved dynamically since the local-cluster's
-	// namespace name is not guaranteed to be literally "local-cluster".
+	// namespace name is not guaranteed to be literally "local-cluster". If the lookup
+	// itself fails, fail closed rather than risk labeling local-cluster resources for
+	// backup: skip this reconcile's hive resource prep entirely and retry next cycle.
 	localClusterName, err := getLocalClusterName(ctx, c)
 	if err != nil {
-		logger.Error(err, "updateHiveResources: error looking up local-cluster name")
+		logger.Error(err, "updateHiveResources: error looking up local-cluster name, skipping this cycle")
+		return
 	}
 
 	// update secrets for clusterDeployments created by cluster claims
@@ -969,7 +972,8 @@ func prepareClusterPoolDeployment(ctx context.Context,
 		// label already set
 		return
 	}
-	logger.Info("Patching disable-creation-webhook-for-dr label on deployment " + clusterDeployment.Name)
+	logger.Info("Patching disable-creation-webhook-for-dr label on deployment",
+		"name", clusterDeployment.Name, "namespace", clusterDeployment.Namespace)
 
 	patch := `[ { "op": "add", "path": "` + hive_label_path + `", "value": "true" } ]`
 	if _, err := dr.Namespace(clusterDeployment.GetNamespace()).Patch(ctx, clusterDeployment.GetName(),

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -3219,3 +3219,58 @@ func Test_updateHiveResources_FailsClosedOnLocalClusterLookupError(t *testing.T)
 			gotOtherSecret.GetLabels())
 	}
 }
+
+// Test_updateHiveResources_SkipsLocalClusterClusterPool verifies that a ClusterPool in
+// the local-cluster namespace is skipped by updateHiveResources: its namespace's
+// secrets must not be auto-labeled for backup, even though the same ClusterPool shape
+// in any other namespace would have its matching secrets labeled.
+func Test_updateHiveResources_SkipsLocalClusterClusterPool(t *testing.T) {
+	setupTestLogger()
+	ctx := createTestContext()
+	scheme := createHiveClusterTestScheme()
+
+	localNs := "local-cluster"
+	otherNs := "pool-ns"
+
+	localPool := &hivev1.ClusterPool{
+		ObjectMeta: v1.ObjectMeta{Name: "local-pool", Namespace: localNs},
+	}
+	otherPool := &hivev1.ClusterPool{
+		ObjectMeta: v1.ObjectMeta{Name: "other-pool", Namespace: otherNs},
+	}
+	localPoolSecret := createTestSecret("local-pool-creds", localNs, nil, nil)
+	otherPoolSecret := createTestSecret("other-pool-creds", otherNs, nil, nil)
+
+	// a ManagedCluster labeled local-cluster:true resolves getLocalClusterName() to
+	// "local-cluster", matching the namespace used by localPool above
+	localManagedCluster := createTestManagedCluster(localNs, true)
+
+	k8sClient := createFakeClient(scheme, localPoolSecret, otherPoolSecret, localManagedCluster,
+		localPool, otherPool)
+	dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	dr := dynClient.Resource(schema.GroupVersionResource{
+		Group: "hive.openshift.io", Version: "v1", Resource: "clusterdeployments",
+	})
+
+	updateHiveResources(ctx, k8sClient, dr)
+
+	gotLocalSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: localNs, Name: localPoolSecret.Name},
+		gotLocalSecret); err != nil {
+		t.Fatalf("failed to get local-cluster pool secret: %v", err)
+	}
+	if _, found := gotLocalSecret.GetLabels()[backupCredsClusterLabel]; found {
+		t.Errorf("expected local-cluster ClusterPool secret to NOT be labeled for backup, got labels %v",
+			gotLocalSecret.GetLabels())
+	}
+
+	gotOtherSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: otherNs, Name: otherPoolSecret.Name},
+		gotOtherSecret); err != nil {
+		t.Fatalf("failed to get non-local pool secret: %v", err)
+	}
+	if gotOtherSecret.GetLabels()[backupCredsClusterLabel] != "clusterpool" {
+		t.Errorf("expected non-local-cluster ClusterPool secret to be labeled for backup, got labels %v",
+			gotOtherSecret.GetLabels())
+	}
+}

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -3005,6 +3005,16 @@ func createHiveTestScheme() *runtime.Scheme {
 	return scheme
 }
 
+// createHiveClusterTestScheme extends createHiveTestScheme with clusterv1, for tests
+// that also need a ManagedCluster (e.g. to resolve the local-cluster name).
+func createHiveClusterTestScheme() *runtime.Scheme {
+	scheme := createHiveTestScheme()
+	if err := clusterv1.Install(scheme); err != nil {
+		panic("Error adding clusterv1 to scheme: " + err.Error())
+	}
+	return scheme
+}
+
 // Test_updateHiveReferencedSecrets verifies that secrets and configmaps explicitly
 // referenced by name on a ClusterDeployment (CertificateBundles, Provisioning's
 // ManifestsSecretRef/ManifestsConfigMapRef) are automatically labeled for backup,
@@ -3051,18 +3061,18 @@ func Test_updateHiveReferencedSecrets(t *testing.T) {
 	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: certSecret.Name}, gotCertSecret); err != nil {
 		t.Fatalf("failed to get cert secret: %v", err)
 	}
-	if gotCertSecret.GetLabels()[backupCredsClusterLabel] != certificate_bundle_label_value {
+	if gotCertSecret.GetLabels()[backupCredsClusterLabel] != certificateBundleLabelValue {
 		t.Errorf("expected certificateBundle secret to have backup label %q=%q, got labels %v",
-			backupCredsClusterLabel, certificate_bundle_label_value, gotCertSecret.GetLabels())
+			backupCredsClusterLabel, certificateBundleLabelValue, gotCertSecret.GetLabels())
 	}
 
 	gotPullSecret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: pullSecret.Name}, gotPullSecret); err != nil {
 		t.Fatalf("failed to get pull secret: %v", err)
 	}
-	if gotPullSecret.GetLabels()[backupCredsClusterLabel] != pull_secret_label_value {
+	if gotPullSecret.GetLabels()[backupCredsClusterLabel] != pullSecretLabelValue {
 		t.Errorf("expected pullSecretRef secret to have backup label %q=%q, got labels %v",
-			backupCredsClusterLabel, pull_secret_label_value, gotPullSecret.GetLabels())
+			backupCredsClusterLabel, pullSecretLabelValue, gotPullSecret.GetLabels())
 	}
 
 	gotManifestsSecret := &corev1.Secret{}
@@ -3070,9 +3080,9 @@ func Test_updateHiveReferencedSecrets(t *testing.T) {
 		gotManifestsSecret); err != nil {
 		t.Fatalf("failed to get manifests secret: %v", err)
 	}
-	if gotManifestsSecret.GetLabels()[backupCredsClusterLabel] != manifests_secret_label_value {
+	if gotManifestsSecret.GetLabels()[backupCredsClusterLabel] != manifestsSecretLabelValue {
 		t.Errorf("expected manifestsSecretRef secret to have backup label %q=%q, got labels %v",
-			backupCredsClusterLabel, manifests_secret_label_value, gotManifestsSecret.GetLabels())
+			backupCredsClusterLabel, manifestsSecretLabelValue, gotManifestsSecret.GetLabels())
 	}
 
 	gotManifestsConfigMap := &corev1.ConfigMap{}
@@ -3080,9 +3090,9 @@ func Test_updateHiveReferencedSecrets(t *testing.T) {
 		gotManifestsConfigMap); err != nil {
 		t.Fatalf("failed to get manifests configmap: %v", err)
 	}
-	if gotManifestsConfigMap.GetLabels()[backupCredsClusterLabel] != manifests_configmap_label_value {
+	if gotManifestsConfigMap.GetLabels()[backupCredsClusterLabel] != manifestsConfigMapLabelValue {
 		t.Errorf("expected manifestsConfigMapRef configmap to have backup label %q=%q, got labels %v",
-			backupCredsClusterLabel, manifests_configmap_label_value, gotManifestsConfigMap.GetLabels())
+			backupCredsClusterLabel, manifestsConfigMapLabelValue, gotManifestsConfigMap.GetLabels())
 	}
 
 	gotAlreadyLabeled := &corev1.Secret{}
@@ -3096,5 +3106,75 @@ func Test_updateHiveReferencedSecrets(t *testing.T) {
 	if gotAlreadyLabeled.GetLabels()[backupCredsUserLabel] != "user-set" {
 		t.Errorf("expected already-labeled secret to keep its original label, got labels %v",
 			gotAlreadyLabeled.GetLabels())
+	}
+}
+
+// Test_updateHiveResources_SkipsLocalCluster verifies that a ClusterDeployment in the
+// local-cluster namespace is skipped entirely by updateHiveResources: restoring
+// local-cluster resources would corrupt the target hub, so referenced secrets there
+// must not be auto-labeled for backup, even though the same ClusterDeployment shape in
+// any other namespace would be.
+func Test_updateHiveResources_SkipsLocalCluster(t *testing.T) {
+	setupTestLogger()
+	ctx := createTestContext()
+	scheme := createHiveClusterTestScheme()
+
+	localNs := "local-cluster"
+	otherNs := "managed-ns"
+
+	localCertSecret := createTestSecret("local-cert-secret", localNs, nil, nil)
+	otherCertSecret := createTestSecret("other-cert-secret", otherNs, nil, nil)
+
+	// a ManagedCluster labeled local-cluster:true resolves getLocalClusterName() to
+	// "local-cluster", matching the namespace used by localClusterDeployment below
+	localManagedCluster := createTestManagedCluster(localNs, true)
+
+	localClusterDeployment := &hivev1.ClusterDeployment{
+		ObjectMeta: v1.ObjectMeta{Name: "local-cd", Namespace: localNs},
+		Spec: hivev1.ClusterDeploymentSpec{
+			CertificateBundles: []hivev1.CertificateBundleSpec{
+				{CertificateSecretRef: corev1.LocalObjectReference{Name: localCertSecret.Name}},
+			},
+		},
+	}
+	otherClusterDeployment := &hivev1.ClusterDeployment{
+		ObjectMeta: v1.ObjectMeta{Name: "other-cd", Namespace: otherNs},
+		Spec: hivev1.ClusterDeploymentSpec{
+			CertificateBundles: []hivev1.CertificateBundleSpec{
+				{CertificateSecretRef: corev1.LocalObjectReference{Name: otherCertSecret.Name}},
+			},
+		},
+	}
+
+	k8sClient := createFakeClient(scheme, localCertSecret, otherCertSecret, localManagedCluster,
+		localClusterDeployment, otherClusterDeployment)
+
+	// updateHiveResources only touches dr when ClusterPoolRef is set, which neither
+	// test ClusterDeployment does, so an empty dynamic client is sufficient here.
+	dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	dr := dynClient.Resource(schema.GroupVersionResource{
+		Group: "hive.openshift.io", Version: "v1", Resource: "clusterdeployments",
+	})
+
+	updateHiveResources(ctx, k8sClient, dr)
+
+	gotLocalSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: localNs, Name: localCertSecret.Name},
+		gotLocalSecret); err != nil {
+		t.Fatalf("failed to get local-cluster cert secret: %v", err)
+	}
+	if _, found := gotLocalSecret.GetLabels()[backupCredsClusterLabel]; found {
+		t.Errorf("expected local-cluster secret to NOT be labeled for backup, got labels %v",
+			gotLocalSecret.GetLabels())
+	}
+
+	gotOtherSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: otherNs, Name: otherCertSecret.Name},
+		gotOtherSecret); err != nil {
+		t.Fatalf("failed to get non-local cert secret: %v", err)
+	}
+	if gotOtherSecret.GetLabels()[backupCredsClusterLabel] != certificateBundleLabelValue {
+		t.Errorf("expected non-local-cluster secret to be labeled for backup, got labels %v",
+			gotOtherSecret.GetLabels())
 	}
 }

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -39,6 +39,7 @@ import (
 	"testing"
 	"time"
 
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -2988,5 +2989,112 @@ func Test_updateSecret(t *testing.T) {
 				t.Errorf("Expected updateSecret to return %v, got %v", tt.expectUpdate, result)
 			}
 		})
+	}
+}
+
+// createHiveTestScheme creates a scheme with core APIs and hive APIs, for tests that
+// exercise ClusterDeployment-referenced secret/configmap labeling.
+func createHiveTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		panic("Error adding corev1 to scheme: " + err.Error())
+	}
+	if err := hivev1.AddToScheme(scheme); err != nil {
+		panic("Error adding hivev1 to scheme: " + err.Error())
+	}
+	return scheme
+}
+
+// Test_updateHiveReferencedSecrets verifies that secrets and configmaps explicitly
+// referenced by name on a ClusterDeployment (CertificateBundles, Provisioning's
+// ManifestsSecretRef/ManifestsConfigMapRef) are automatically labeled for backup,
+// without requiring the user to label them manually. See ACM-38831.
+func Test_updateHiveReferencedSecrets(t *testing.T) {
+	setupTestLogger()
+	ctx := createTestContext()
+	scheme := createHiveTestScheme()
+
+	ns := "cd-ns"
+
+	certSecret := createTestSecret("cert-bundle-secret", ns, nil, nil)
+	pullSecret := createTestSecret("pull-secret", ns, nil, nil)
+	manifestsSecret := createTestSecret("manifests-secret", ns, nil, nil)
+	manifestsConfigMap := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{Name: "manifests-cm", Namespace: ns},
+	}
+	// a secret that already carries a backup label should not be re-labeled with a
+	// different value
+	alreadyLabeledCertSecret := createTestSecret("already-labeled-cert-secret", ns,
+		map[string]string{backupCredsUserLabel: "user-set"}, nil)
+
+	k8sClient := createFakeClient(scheme, certSecret, pullSecret, manifestsSecret, manifestsConfigMap,
+		alreadyLabeledCertSecret)
+
+	clusterDeployment := hivev1.ClusterDeployment{
+		ObjectMeta: v1.ObjectMeta{Name: "cd", Namespace: ns},
+		Spec: hivev1.ClusterDeploymentSpec{
+			CertificateBundles: []hivev1.CertificateBundleSpec{
+				{CertificateSecretRef: corev1.LocalObjectReference{Name: certSecret.Name}},
+				{CertificateSecretRef: corev1.LocalObjectReference{Name: alreadyLabeledCertSecret.Name}},
+			},
+			PullSecretRef: &corev1.LocalObjectReference{Name: pullSecret.Name},
+			Provisioning: &hivev1.Provisioning{
+				ManifestsSecretRef:    &corev1.LocalObjectReference{Name: manifestsSecret.Name},
+				ManifestsConfigMapRef: &corev1.LocalObjectReference{Name: manifestsConfigMap.Name},
+			},
+		},
+	}
+
+	updateHiveReferencedSecrets(ctx, k8sClient, clusterDeployment)
+
+	gotCertSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: certSecret.Name}, gotCertSecret); err != nil {
+		t.Fatalf("failed to get cert secret: %v", err)
+	}
+	if gotCertSecret.GetLabels()[backupCredsClusterLabel] != certificate_bundle_label_value {
+		t.Errorf("expected certificateBundle secret to have backup label %q=%q, got labels %v",
+			backupCredsClusterLabel, certificate_bundle_label_value, gotCertSecret.GetLabels())
+	}
+
+	gotPullSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: pullSecret.Name}, gotPullSecret); err != nil {
+		t.Fatalf("failed to get pull secret: %v", err)
+	}
+	if gotPullSecret.GetLabels()[backupCredsClusterLabel] != pull_secret_label_value {
+		t.Errorf("expected pullSecretRef secret to have backup label %q=%q, got labels %v",
+			backupCredsClusterLabel, pull_secret_label_value, gotPullSecret.GetLabels())
+	}
+
+	gotManifestsSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: manifestsSecret.Name},
+		gotManifestsSecret); err != nil {
+		t.Fatalf("failed to get manifests secret: %v", err)
+	}
+	if gotManifestsSecret.GetLabels()[backupCredsClusterLabel] != manifests_secret_label_value {
+		t.Errorf("expected manifestsSecretRef secret to have backup label %q=%q, got labels %v",
+			backupCredsClusterLabel, manifests_secret_label_value, gotManifestsSecret.GetLabels())
+	}
+
+	gotManifestsConfigMap := &corev1.ConfigMap{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: manifestsConfigMap.Name},
+		gotManifestsConfigMap); err != nil {
+		t.Fatalf("failed to get manifests configmap: %v", err)
+	}
+	if gotManifestsConfigMap.GetLabels()[backupCredsClusterLabel] != manifests_configmap_label_value {
+		t.Errorf("expected manifestsConfigMapRef configmap to have backup label %q=%q, got labels %v",
+			backupCredsClusterLabel, manifests_configmap_label_value, gotManifestsConfigMap.GetLabels())
+	}
+
+	gotAlreadyLabeled := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: alreadyLabeledCertSecret.Name},
+		gotAlreadyLabeled); err != nil {
+		t.Fatalf("failed to get already-labeled cert secret: %v", err)
+	}
+	if gotAlreadyLabeled.GetLabels()[backupCredsClusterLabel] != "" {
+		t.Errorf("expected already-labeled secret to be left alone, got labels %v", gotAlreadyLabeled.GetLabels())
+	}
+	if gotAlreadyLabeled.GetLabels()[backupCredsUserLabel] != "user-set" {
+		t.Errorf("expected already-labeled secret to keep its original label, got labels %v",
+			gotAlreadyLabeled.GetLabels())
 	}
 }

--- a/controllers/pre_backup_test.go
+++ b/controllers/pre_backup_test.go
@@ -3178,3 +3178,44 @@ func Test_updateHiveResources_SkipsLocalCluster(t *testing.T) {
 			gotOtherSecret.GetLabels())
 	}
 }
+
+// Test_updateHiveResources_FailsClosedOnLocalClusterLookupError verifies that if
+// getLocalClusterName cannot be resolved (e.g. a transient API error), updateHiveResources
+// fails closed: it skips labeling entirely for this cycle rather than risk labeling
+// local-cluster resources for backup because the exclusion check couldn't be evaluated.
+func Test_updateHiveResources_FailsClosedOnLocalClusterLookupError(t *testing.T) {
+	setupTestLogger()
+	ctx := createTestContext()
+	// deliberately omit clusterv1 from the scheme so the ManagedClusterList lookup inside
+	// getLocalClusterName fails, simulating an error resolving the local-cluster name
+	scheme := createHiveTestScheme()
+
+	otherNs := "managed-ns"
+	otherCertSecret := createTestSecret("other-cert-secret", otherNs, nil, nil)
+	otherClusterDeployment := &hivev1.ClusterDeployment{
+		ObjectMeta: v1.ObjectMeta{Name: "other-cd", Namespace: otherNs},
+		Spec: hivev1.ClusterDeploymentSpec{
+			CertificateBundles: []hivev1.CertificateBundleSpec{
+				{CertificateSecretRef: corev1.LocalObjectReference{Name: otherCertSecret.Name}},
+			},
+		},
+	}
+
+	k8sClient := createFakeClient(scheme, otherCertSecret, otherClusterDeployment)
+	dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	dr := dynClient.Resource(schema.GroupVersionResource{
+		Group: "hive.openshift.io", Version: "v1", Resource: "clusterdeployments",
+	})
+
+	updateHiveResources(ctx, k8sClient, dr)
+
+	gotOtherSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: otherNs, Name: otherCertSecret.Name},
+		gotOtherSecret); err != nil {
+		t.Fatalf("failed to get non-local cert secret: %v", err)
+	}
+	if _, found := gotOtherSecret.GetLabels()[backupCredsClusterLabel]; found {
+		t.Errorf("expected no labeling to occur when the local-cluster lookup fails, got labels %v",
+			gotOtherSecret.GetLabels())
+	}
+}


### PR DESCRIPTION
Auto-labels secrets/configmaps that a `ClusterDeployment` explicitly references by name (`certificateBundles`, `pullSecretRef`, `provisioning.manifestsSecretRef`/`manifestsConfigMapRef`) so they're picked up for backup without requiring the user to label them manually.

Resolves [ACM-38831](https://redhat.atlassian.net/browse/ACM-38831)


[ACM-38831]: https://redhat.atlassian.net/browse/ACM-38831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved backup handling for secrets and configuration maps explicitly referenced by cluster deployments.
  * Cluster pool deployments now receive appropriate backup labeling and configuration updates.
  * Certificate bundles, pull secrets, provisioning manifests, and related configuration resources are included when applicable.
  * Existing backup labels are preserved.
  * Local cluster resources and unsupported service-account signing-key references remain excluded from backup processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->