### PR TITLE
Route ClusterInstance into the managed-clusters activation tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ With this approach the backup includes all CRDs installed on the hub, including 
 
 1. Exclude all resources in the MultiClusterHub namespace. This is to avoid backing up installation resources which are linked to the current Hub identity and should not be backed up.
 2. Backup all CRDs with an api version suffixed by `.open-cluster-management.io` and `.hive.openshift.io`. This will cover all Advanced Cluster Management resources.
-3. Additionally, backup all CRDs from these api groups: `argoproj.io`,`app.k8s.io`,`core.observatorium.io`,`hive.openshift.io` under the resources backup and all CRDs from this group `agent-install.openshift.io` under the managed-clusters backup.
+3. Additionally, backup all CRDs from these api groups: `argoproj.io`,`app.k8s.io`,`core.observatorium.io`,`hive.openshift.io` under the resources backup and all CRDs from these groups `agent-install.openshift.io` and `siteconfig.open-cluster-management.io` under the managed-clusters backup. Routing `siteconfig.open-cluster-management.io` (the `ClusterInstance` resource used for ZTP/bare-metal managed clusters) here ensures it is only restored during an actual failover, not on every routine passive-sync cycle.
 4. Exclude all CRDs from the following api groups : 
 		"internal.open-cluster-management.io",
 		"operator.open-cluster-management.io",
@@ -292,6 +292,8 @@ Aside of these activation data resources, identified by using the `cluster.open-
   - machinepool.hive.openshift.io
   - clustersync.hiveinternal.openshift.io
   - clustercurator.cluster.open-cluster-management.io
+
+In addition to this fixed list, all CRDs belonging to the `agent-install.openshift.io` and `siteconfig.open-cluster-management.io` api groups (for example `ClusterInstance`, used by ZTP/bare-metal managed clusters) are automatically included in the activation set as well, so they are only restored when `veleroManagedClustersBackupName:latest` is used.
 
 ### Passive data
 

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -67,6 +67,13 @@ var (
 	}
 	includedActivationAPIGroupsByName = []string{
 		"agent-install.openshift.io",
+		// siteconfig.open-cluster-management.io (ClusterInstance) drives Day-1 installs for
+		// ZTP/bare-metal managed clusters. Treating it as an activation resource ensures it
+		// is only restored during an actual failover (VeleroManagedClustersBackupName=latest),
+		// not on every routine passive-sync cycle, which would otherwise cause the SiteConfig
+		// controller to re-render Day-1 manifests against already-installed clusters and drive
+		// their BareMetalHost objects back into Inspecting. See ACM-39330.
+		"siteconfig.open-cluster-management.io",
 	}
 
 	// exclude resources from these api groups

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -454,6 +454,11 @@ func processResourcesToBackup(
 	backupResourceNames := backupResources
 	// build the list of excluded resources
 	ignoreCRDs := excludedCRDs
+	// work on a local copy of the package-level activation resources so this function
+	// doesn't mutate shared state on every matched resource (avoids stale reads/races
+	// across discovery calls); the package variable is updated once, after discovery
+	// completes, below.
+	managedClusterResources := append([]string{}, backupManagedClusterResources...)
 
 	for _, group := range groupList.Groups {
 
@@ -483,7 +488,7 @@ func processResourcesToBackup(
 					// if resource kind is not ignored
 					// and this is an activation group
 					// then add the resource to the activation list
-					backupManagedClusterResources = appendUnique(backupManagedClusterResources, resourceName)
+					managedClusterResources = appendUnique(managedClusterResources, resourceName)
 				}
 
 				// if resource kind is not ignored
@@ -492,13 +497,14 @@ func processResourcesToBackup(
 				if !findValue(includedActivationAPIGroupsByName, group.Name) &&
 					!findValue(ignoreCRDs, resourceKind) &&
 					!findValue(ignoreCRDs, resourceName) &&
-					!findValue(backupManagedClusterResources, resourceKind) &&
-					!findValue(backupManagedClusterResources, resourceName) {
+					!findValue(managedClusterResources, resourceKind) &&
+					!findValue(managedClusterResources, resourceName) {
 					backupResourceNames = appendUnique(backupResourceNames, resourceName)
 				}
 			}
 		}
 	}
+	backupManagedClusterResources = managedClusterResources
 	return backupResourceNames
 }
 

--- a/controllers/backup_test.go
+++ b/controllers/backup_test.go
@@ -47,6 +47,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	clientgotesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -349,6 +351,61 @@ func verifyDeletedBackups(t *testing.T, deletedBackups map[string]bool, allBacku
 		if !found {
 			t.Errorf("Unknown backup %s was deleted", backupName)
 		}
+	}
+}
+
+// Test_processResourcesToBackup_routesClusterInstanceToActivationResources verifies that
+// ClusterInstance (siteconfig.open-cluster-management.io), like the pre-existing
+// agent-install.openshift.io group, is routed into the activation resource set
+// (backupManagedClusterResources) rather than the generic Resources backup list.
+// This ensures ClusterInstance is only restored during an actual failover
+// (VeleroManagedClustersBackupName=latest), not on every routine passive-sync cycle. See ACM-39330.
+func Test_processResourcesToBackup_routesClusterInstanceToActivationResources(t *testing.T) {
+	// processResourcesToBackup mutates the package-level backupManagedClusterResources
+	// slice; save and restore it so this test doesn't leak state into other tests.
+	originalManagedClusterResources := backupManagedClusterResources
+	backupManagedClusterResources = append([]string{}, originalManagedClusterResources...)
+	defer func() { backupManagedClusterResources = originalManagedClusterResources }()
+
+	groupList := metav1.APIGroupList{
+		Groups: []metav1.APIGroup{
+			{
+				Name: "siteconfig.open-cluster-management.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "siteconfig.open-cluster-management.io/v1alpha1"},
+				},
+			},
+		},
+	}
+
+	fakeDC := &discoveryfake.FakeDiscovery{
+		Fake: &clientgotesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "siteconfig.open-cluster-management.io/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Kind: "ClusterInstance"},
+					},
+				},
+			},
+		},
+	}
+
+	backupResourceNames := processResourcesToBackup(context.Background(), fakeDC, groupList)
+
+	const clusterInstanceResource = "clusterinstance.siteconfig.open-cluster-management.io"
+
+	if findValue(backupResourceNames, clusterInstanceResource) {
+		t.Errorf(
+			"expected ClusterInstance to NOT be routed to the generic Resources backup list, got %v",
+			backupResourceNames,
+		)
+	}
+	if !findValue(backupManagedClusterResources, clusterInstanceResource) {
+		t.Errorf(
+			"expected ClusterInstance to be routed to backupManagedClusterResources (activation tier), got %v",
+			backupManagedClusterResources,
+		)
 	}
 }
 


### PR DESCRIPTION
## What

`ClusterInstance` (`siteconfig.open-cluster-management.io`), used to drive Day-1 installs for ZTP/bare-metal managed clusters, previously matched only the generic `*.open-cluster-management.io` backup rule and landed in the unconditional `Resources` backup/restore tier — meaning it was restored on **every** passive-sync cycle (`veleroManagedClustersBackupName: skip`), not just during an actual failover.

This caused the SiteConfig controller to re-render Day-1 manifests against already-installed, healthy clusters, driving their `BareMetalHost` objects back into `Inspecting` with no failover ever intended — a real risk of an out-of-band reboot against live production hardware.

## Fix

Add `siteconfig.open-cluster-management.io` to `includedActivationAPIGroupsByName`, the same discovery-based mechanism already used for `agent-install.openshift.io`. This routes `ClusterInstance` into the managed-clusters activation backup/restore tier, which already fully respects the `skip`/`latest` gate on `veleroManagedClustersBackupName` — no restore-sequencing changes needed.

We also verified there's no existing Restore-CR-level workaround: the webhook hard-requires `veleroResourcesBackupName: latest` whenever `syncRestoreWithNewBackups: true` is set, so this code fix is the only way to close this exposure.

## Scope

This fixes the routine-passive-sync exposure described in [ACM-39330](https://redhat.atlassian.net/browse/ACM-39330). The restore-ordering-during-a-genuine-failover half of that ticket requires a fix in the SiteConfig Operator controller (`ClusterInstance.status` not being preserved across restore) and is tracked separately with that team.

## Test plan

- [x] New unit test `Test_processResourcesToBackup_routesClusterInstanceToActivationResources` verifies `ClusterInstance` is routed to the activation resource set and excluded from the generic `Resources` backup list
- [x] Full `./controllers/...` and `./pkg/...` suite passes
- [x] `go vet` and `golangci-lint` clean on changed files
- [x] README updated to document the new activation-group entry

Jira: https://redhat.atlassian.net/browse/ACM-39330


[ACM-39330]: https://redhat.atlassian.net/browse/ACM-39330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Managed-cluster backups now include `siteconfig.open-cluster-management.io` resources.
  - Activation restores now restore resources such as `ClusterInstance` during managed-cluster failover.
  - Activation processing now supports the complete set of configured resources.

- **Documentation**
  - Clarified that these resources are restored during failover, but not during passive synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->