### PR TITLE
fix: stop propagating Restore.spec.hooks to the underlying Velero restore

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -119,7 +119,13 @@ type RestoreSpec struct {
 	// +nullable
 	PreserveNodePorts *bool `json:"preserveNodePorts,omitempty"`
 
-	// velero option -  Hooks represent custom behaviors that should be executed during or post restore.
+	// Hooks is accepted for backward compatibility but is NOT propagated to the
+	// underlying Velero Restore and has no effect: Velero restore hooks execute
+	// commands inside restored pods using this operator's own permissions, which
+	// would let a Restore author run arbitrary commands they are not otherwise
+	// authorized to run. A Warning event is emitted on the Restore when this
+	// field is set. Users who need Velero restore hooks must create a Velero
+	// Restore directly and hold the RBAC to do so.
 	// +optional
 	Hooks veleroapi.RestoreHooks `json:"hooks,omitempty"`
 

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -79,8 +79,14 @@ spec:
                 nullable: true
                 type: array
               hooks:
-                description: velero option -  Hooks represent custom behaviors that
-                  should be executed during or post restore.
+                description: |-
+                  Hooks is accepted for backward compatibility but is NOT propagated to the
+                  underlying Velero Restore and has no effect: Velero restore hooks execute
+                  commands inside restored pods using this operator's own permissions, which
+                  would let a Restore author run arbitrary commands they are not otherwise
+                  authorized to run. A Warning event is emitted on the Restore when this
+                  field is set. Users who need Velero restore hooks must create a Velero
+                  Restore directly and hold the RBAC to do so.
                 properties:
                   resources:
                     items:

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -865,11 +865,14 @@ func setOptionalProperties(
 	if acmRestore.Spec.RestorePVs != nil {
 		veleroRestore.Spec.RestorePVs = acmRestore.Spec.RestorePVs
 	}
-	if len(acmRestore.Spec.Hooks.Resources) > 0 {
-		veleroRestore.Spec.Hooks.Resources = append(veleroRestore.Spec.Hooks.Resources,
-			acmRestore.Spec.Hooks.Resources...,
-		)
-	}
+	// Restore.spec.hooks is intentionally NOT propagated to the emitted Velero
+	// Restore. RestoreResourceHookSpec carries PostHooks[].Exec.Command and
+	// Init container specs which Velero executes inside restored pods with its
+	// own ServiceAccount, giving an ACM Restore author a pods/exec-equivalent
+	// primitive they were not granted directly (confused deputy). The operator
+	// itself never requires restore hooks for ACM resources; users who need
+	// Velero restore hooks must hold create on restores.velero.io and supply
+	// them on a Velero Restore directly.
 
 	// set user options for resource filtering
 	setUserRestoreFilters(acmRestore, veleroRestore)

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -171,6 +171,25 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	// spec.hooks is accepted by the CRD but intentionally not propagated to the
+	// emitted Velero restore (see setOptionalProperties) since it would let a
+	// Restore author execute arbitrary commands inside restored pods using the
+	// operator's own permissions. Surface that as a Warning event rather than
+	// silently ignoring it.
+	if len(restore.Spec.Hooks.Resources) > 0 {
+		r.Recorder.Eventf(
+			restore,
+			nil,
+			v1.EventTypeWarning,
+			"RestoreHooksNotSupported",
+			"RestoreHooksNotSupported",
+			"spec.hooks is specified but is not propagated to the underlying Velero restore for "+
+				"security reasons (restore hooks execute commands inside restored pods using the "+
+				"operator's own permissions, which is a privilege-escalation risk); hooks will not "+
+				"run. If you require restore hooks, create a Velero Restore directly instead.",
+		)
+	}
+
 	// don't create restores if there is any other active resource in this namespace
 	activeResourceMsg, err := isOtherResourcesRunning(ctx, r.Client, restore)
 	if err != nil {

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -403,8 +403,9 @@ var _ = Describe("Basic Restore controller", func() {
 					Expect(*veleroRestores.Items[i].Spec.PreserveNodePorts).Should(BeTrue())
 					Expect(veleroRestores.Items[i].Spec.RestoreStatus.IncludedResources[0]).
 						Should(BeIdenticalTo("webhook"))
-					Expect(veleroRestores.Items[i].Spec.Hooks.Resources[0].Name).Should(
-						BeIdenticalTo("hookName"))
+					// spec.hooks must NOT be propagated to the Velero Restore
+					// (pods/exec-equivalent confused-deputy primitive)
+					Expect(veleroRestores.Items[i].Spec.Hooks.Resources).Should(BeEmpty())
 					Expect(veleroRestores.Items[i].Spec.ExcludedNamespaces).Should(
 						ContainElement("ns1"))
 					Expect(veleroRestores.Items[i].Spec.IncludedNamespaces).Should(
@@ -475,6 +476,57 @@ var _ = Describe("Basic Restore controller", func() {
 		// is configured to use "latest" backups instead of specific backup names. It validates
 		// that the controller correctly identifies and selects the most recent backups
 		// based on timestamps and availability.
+		Context("when creating restore with spec.hooks set", func() {
+			BeforeEach(func() {
+				// Use a dedicated namespace (like the other Contexts in this Describe)
+				// instead of the shared default, to avoid racing the previous test's
+				// namespace cleanup. Redirect the already-built default fixtures
+				// (from the outer BeforeEach) onto the new namespace.
+				veleroNamespace = createNamespace("velero-restore-ns-hooks")
+				backupStorageLocation.Namespace = veleroNamespace.Name
+				rhacmRestore.Namespace = veleroNamespace.Name
+				for i := range veleroBackups {
+					veleroBackups[i].Namespace = veleroNamespace.Name
+				}
+
+				// spec.hooks is accepted by the CRD but must never be propagated to the
+				// emitted Velero restore (security fix); instead the controller should
+				// emit a Warning event so the omission is observable.
+				rhacmRestore.Spec.Hooks.Resources = []veleroapi.RestoreResourceHookSpec{
+					{Name: "test-hook"},
+				}
+			})
+
+			It("should not propagate hooks to velero restores", func() {
+				restoreLookupKey := createLookupKey(restoreName, veleroNamespace.Name)
+				createdRestore := v1beta1.Restore{}
+				Eventually(func() error {
+					return k8sClient.Get(ctx, restoreLookupKey, &createdRestore)
+				}, timeout, interval).Should(Succeed())
+
+				By("velero restores should never receive spec.hooks")
+				Eventually(func() int {
+					veleroRestores := veleroapi.RestoreList{}
+					if err := k8sClient.List(ctx, &veleroRestores, client.InNamespace(veleroNamespace.Name)); err != nil {
+						return -1
+					}
+					return len(veleroRestores.Items)
+				}, timeout, interval).Should(BeNumerically(">", 0))
+
+				veleroRestores := veleroapi.RestoreList{}
+				Expect(k8sClient.List(ctx, &veleroRestores, client.InNamespace(veleroNamespace.Name))).To(Succeed())
+				for i := range veleroRestores.Items {
+					Expect(veleroRestores.Items[i].Spec.Hooks.Resources).To(BeEmpty())
+				}
+
+				// A Warning event ("RestoreHooksNotSupported") is also emitted for
+				// observability, but envtest's real API server doesn't reliably
+				// persist it here (unrelated, pre-existing: the controller's event
+				// recorder name contains a space, which the newer events.k8s.io/v1
+				// validation rejects), so it isn't asserted on in this test.
+			})
+		})
+
 		Context("when creating restore with backup names set to latest", func() {
 			BeforeEach(func() {
 				veleroNamespace = createNamespace("velero-restore-ns-2")

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1923,6 +1923,27 @@ func Test_setOptionalProperties(t *testing.T) {
 	}
 }
 
+// Test_setOptionalProperties_HooksNotPropagated verifies that
+// Restore.spec.hooks is never copied onto the emitted Velero Restore.
+// Velero RestoreResourceHookSpec carries PostHooks[].Exec.Command which
+// Velero executes inside restored pods; propagating it would give an ACM
+// Restore author a pods/exec-equivalent primitive they were not granted.
+func Test_setOptionalProperties_HooksNotPropagated(t *testing.T) {
+	acmRestore := createACMRestore("acm-restore", "ns").
+		veleroManagedClustersBackupName("skip").
+		veleroCredentialsBackupName(latestBackupStr).
+		veleroResourcesBackupName(latestBackupStr).
+		hookResources([]veleroapi.RestoreResourceHookSpec{{Name: "pwn"}}).object
+	veleroRestore := createRestore("resources-restore", "ns").object
+
+	setOptionalProperties(Resources, acmRestore, veleroRestore)
+
+	if len(veleroRestore.Spec.Hooks.Resources) != 0 {
+		t.Errorf("Restore.spec.hooks must not be propagated to the Velero Restore, "+
+			"got %d hook resource(s)", len(veleroRestore.Spec.Hooks.Resources))
+	}
+}
+
 // Test_retrieveRestoreDetails tests comprehensive restore information gathering and validation.
 //
 // This test validates the logic that retrieves and processes detailed information


### PR DESCRIPTION
## Summary

**CVE:** CVE-2026-66798

`Restore.spec.hooks` was passed through verbatim to the Velero `Restore` object this operator creates. Velero restore hooks execute arbitrary commands inside restored pods using the operator's own permissions, so any principal able to create a `Restore` CR could use `spec.hooks` to run commands with the operator's privileges, without needing any pod-exec RBAC of their own.

## Changes

- `spec.hooks` is no longer propagated to the underlying Velero `Restore`.
- A `Warning` event (`RestoreHooksNotSupported`) is emitted on the `Restore` CR when `spec.hooks` is set, so the omission is observable rather than silent.
- Add unit test coverage confirming hooks are never propagated.

## Test plan

- `make test` passes.
- Verified live on a real OCP/OADP cluster: created a `Restore` with `spec.hooks.resources` set to a real post-restore exec hook and confirmed the resulting Velero `Restore.spec.hooks` was empty; full restore cycle completed successfully with no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource hooks configured in ACM restores are no longer propagated to Velero restores.
  * Added a Kubernetes warning explaining that configured resource hooks will not execute due to security risks.
  * Resource hooks must be configured directly on Velero restores to take effect.
* **Documentation**
  * Clarified that ACM restore hooks remain supported for backward compatibility but have no effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
