### PR TITLE
fix: reject Restore.spec.namespaceMapping targets in protected system namespaces

### DIFF
--- a/api/v1beta1/restore_webhook.go
+++ b/api/v1beta1/restore_webhook.go
@@ -61,6 +61,11 @@ func (r *Restore) ValidateDelete(ctx context.Context, restore *Restore) (admissi
 func (r *Restore) validateRestore() (admission.Warnings, error) {
 	var warnings admission.Warnings
 
+	// Validate namespaceMapping does not target protected system namespaces
+	if err := r.validateNamespaceMapping(); err != nil {
+		return warnings, err
+	}
+
 	// Validate sync mode configuration
 	if r.Spec.SyncRestoreWithNewBackups {
 		if err := r.validateSyncMode(); err != nil {
@@ -69,6 +74,34 @@ func (r *Restore) validateRestore() (admission.Warnings, error) {
 	}
 
 	return warnings, nil
+}
+
+// isProtectedNamespaceMappingTarget returns true if the namespace is a
+// platform-reserved namespace that must never be a NamespaceMapping target.
+// Velero applies restored objects with a near-cluster-admin ServiceAccount,
+// so allowing a Restore author to redirect backed-up Secrets/ConfigMaps into
+// kube-* or openshift-* namespaces is a cross-namespace write primitive.
+func isProtectedNamespaceMappingTarget(ns string) bool {
+	ns = strings.ToLower(strings.TrimSpace(ns))
+	return ns == "default" ||
+		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
+		strings.HasPrefix(ns, "kube-") ||
+		strings.HasPrefix(ns, "openshift-")
+}
+
+// validateNamespaceMapping rejects NamespaceMapping entries whose target is a
+// protected system namespace. NamespaceMapping is passed verbatim to the
+// emitted Velero Restore, so this check is the only guard between a Restore
+// author and Velero create/update of arbitrary objects in system namespaces.
+func (r *Restore) validateNamespaceMapping() error {
+	for src, dst := range r.Spec.NamespaceMapping {
+		if isProtectedNamespaceMappingTarget(dst) {
+			return fmt.Errorf(
+				"spec.namespaceMapping[%q]: target namespace %q is a protected system "+
+					"namespace and may not be used as a restore destination", src, dst)
+		}
+	}
+	return nil
 }
 
 // validateSyncMode validates sync mode specific requirements

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -111,6 +111,45 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			errSubstr: "must initially be set to 'skip'",
 		},
 		{
+			name: "invalid namespaceMapping - kube-system target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"src-ns": "kube-system"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "invalid namespaceMapping - openshift-config target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "openshift-config"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "invalid namespaceMapping - default target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "default"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "valid namespaceMapping - non-system target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"old-ns": "new-acm-ns"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid sync - MC latest when Phase=Enabled (activation)",
 			restore: &Restore{
 				Spec: RestoreSpec{


### PR DESCRIPTION
## Summary

**CVE:** CVE-2026-66799

`Restore.spec.namespaceMapping` lets a `Restore` CR remap a backed-up namespace to a different target namespace on restore. The target was not validated, so a `Restore` CR could map any backed-up namespace onto a protected system namespace (`default`, `kube-*`, `openshift-*`), letting its contents be created or overwritten there using the operator's own permissions.

## Changes

- The admission webhook now rejects `Restore` CRs whose `namespaceMapping` targets fall into a protected namespace, with a clear validation error naming the offending mapping.
- Add unit test coverage for both the rejection and the unaffected non-protected-namespace case.

## Test plan

- `make test` passes.
- Verified live on a real OCP/OADP cluster: a `Restore` mapping into `kube-system` / `openshift-monitoring` was rejected at admission with the expected error; a `Restore` mapping into a normal namespace was accepted as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restore validation now checks namespace mappings before sync-mode validation.
  * Prevents restores from targeting protected Kubernetes and OpenShift namespaces.
  * Error messages identify the source and destination namespaces for invalid mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
