### PR TITLE
fix: remove space from Restore controller's event recorder name

### DIFF
--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -42,6 +42,7 @@ import (
 	v1beta1 "github.com/stolostron/cluster-backup-operator/api/v1beta1"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -519,11 +520,20 @@ var _ = Describe("Basic Restore controller", func() {
 					Expect(veleroRestores.Items[i].Spec.Hooks.Resources).To(BeEmpty())
 				}
 
-				// A Warning event ("RestoreHooksNotSupported") is also emitted for
-				// observability, but envtest's real API server doesn't reliably
-				// persist it here (unrelated, pre-existing: the controller's event
-				// recorder name contains a space, which the newer events.k8s.io/v1
-				// validation rejects), so it isn't asserted on in this test.
+				By("a Warning event should be emitted for observability")
+				Eventually(func() bool {
+					events := eventsv1.EventList{}
+					if err := k8sClient.List(ctx, &events, client.InNamespace(veleroNamespace.Name)); err != nil {
+						return false
+					}
+					for i := range events.Items {
+						if events.Items[i].Reason == "RestoreHooksNotSupported" &&
+							events.Items[i].Type == corev1.EventTypeWarning {
+							return true
+						}
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
 			})
 		})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -185,7 +185,7 @@ var _ = BeforeSuite(func() {
 		Scheme:          mgr.GetScheme(),
 		DiscoveryClient: fakeDiscovery,
 		DynamicClient:   dynR,
-		Recorder: mgr.GetEventRecorder("restore reconciler"),
+		Recorder:        mgr.GetEventRecorder("restore-controller"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func main() {
 		DiscoveryClient: dc,
 		DynamicClient:   dyn,
 		Scheme:          mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("Restore controller"),
+		Recorder:        mgr.GetEventRecorder("restore-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Restore controller")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

The `RestoreReconciler`'s `events.EventRecorder` is created with the name `"Restore controller"` (and `"restore reconciler"` in the envtest suite setup), which contains a space. The `events.k8s.io/v1` API server validation rejects `Event` objects whose `reportingController` doesn't match a DNS-1123-like identifier, so **every event this controller emits silently fails to persist** — there's no error surfaced to the operator, its logs, or the user; the event object is simply never created.

This means any `Warning`/`Normal` event emitted from `RestoreReconciler` (e.g. the `RestoreHooksNotSupported` warning) is currently invisible on a real cluster.

## Changes

- Rename both recorder instances from `"Restore controller"` / `"restore reconciler"` to `"restore-controller"`.
- Re-enable the previously-skipped event assertion in the `spec.hooks` test now that it can reliably observe the emitted `Warning` event (it was skipped with a comment noting this exact issue).

## Test plan

- `make test` passes, including the re-enabled event assertion, which I verified newly passes with this fix (and would fail without it, since that's how the gap was originally discovered).
- `make lint` / `go vet` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal event recorder name for Restore reconciliation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->