### PR TITLE
fix: reject Restore.spec.namespaceMapping targets in protected system namespaces [rhacm-2.17]

### DIFF
--- a/api/v1beta1/restore_webhook.go
+++ b/api/v1beta1/restore_webhook.go
@@ -102,7 +102,7 @@ func (r *Restore) validateRestore() (admission.Warnings, error) {
 // kube-* or openshift-* namespaces is a cross-namespace write primitive.
 func isProtectedNamespaceMappingTarget(ns string) bool {
 	ns = strings.ToLower(strings.TrimSpace(ns))
-	return ns == "default" ||
+	return ns == "default" || ns == "openshift" ||
 		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
 		strings.HasPrefix(ns, "kube-") ||
 		strings.HasPrefix(ns, "openshift-")

--- a/api/v1beta1/restore_webhook.go
+++ b/api/v1beta1/restore_webhook.go
@@ -80,6 +80,11 @@ func (r *Restore) ValidateDelete(ctx context.Context, obj runtime.Object) (admis
 func (r *Restore) validateRestore() (admission.Warnings, error) {
 	var warnings admission.Warnings
 
+	// Validate namespaceMapping does not target protected system namespaces
+	if err := r.validateNamespaceMapping(); err != nil {
+		return warnings, err
+	}
+
 	// Validate sync mode configuration
 	if r.Spec.SyncRestoreWithNewBackups {
 		if err := r.validateSyncMode(); err != nil {
@@ -88,6 +93,34 @@ func (r *Restore) validateRestore() (admission.Warnings, error) {
 	}
 
 	return warnings, nil
+}
+
+// isProtectedNamespaceMappingTarget returns true if the namespace is a
+// platform-reserved namespace that must never be a NamespaceMapping target.
+// Velero applies restored objects with a near-cluster-admin ServiceAccount,
+// so allowing a Restore author to redirect backed-up Secrets/ConfigMaps into
+// kube-* or openshift-* namespaces is a cross-namespace write primitive.
+func isProtectedNamespaceMappingTarget(ns string) bool {
+	ns = strings.ToLower(strings.TrimSpace(ns))
+	return ns == "default" ||
+		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
+		strings.HasPrefix(ns, "kube-") ||
+		strings.HasPrefix(ns, "openshift-")
+}
+
+// validateNamespaceMapping rejects NamespaceMapping entries whose target is a
+// protected system namespace. NamespaceMapping is passed verbatim to the
+// emitted Velero Restore, so this check is the only guard between a Restore
+// author and Velero create/update of arbitrary objects in system namespaces.
+func (r *Restore) validateNamespaceMapping() error {
+	for src, dst := range r.Spec.NamespaceMapping {
+		if isProtectedNamespaceMappingTarget(dst) {
+			return fmt.Errorf(
+				"spec.namespaceMapping[%q]: target namespace %q is a protected system "+
+					"namespace and may not be used as a restore destination", src, dst)
+		}
+	}
+	return nil
 }
 
 // validateSyncMode validates sync mode specific requirements

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -131,6 +131,16 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			errSubstr: "protected system namespace",
 		},
 		{
+			name: "invalid namespaceMapping - exact openshift target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "openshift"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
 			name: "invalid namespaceMapping - default target",
 			restore: &Restore{
 				Spec: RestoreSpec{

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -111,6 +111,45 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			errSubstr: "must initially be set to 'skip'",
 		},
 		{
+			name: "invalid namespaceMapping - kube-system target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"src-ns": "kube-system"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "invalid namespaceMapping - openshift-config target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "openshift-config"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "invalid namespaceMapping - default target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "default"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "valid namespaceMapping - non-system target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"old-ns": "new-acm-ns"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid sync - MC latest when Phase=Enabled (activation)",
 			restore: &Restore{
 				Spec: RestoreSpec{


### PR DESCRIPTION
Backport of https://github.com/stolostron/cluster-backup-operator/pull/1698 for CVE-2026-66799.

Related: ACM-38850

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore namespace mappings are now validated before configuration.
  * Prevented mappings to protected namespaces, including `default`, Kubernetes system namespaces, and namespaces beginning with `kube-` or `openshift-`.
  * Error messages identify the source and disallowed destination namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->