### PR TITLE
fix: reject Restore.spec.namespaceMapping targets in protected system namespaces [rhacm-2.16]

### DIFF
--- a/api/v1beta1/restore_webhook.go
+++ b/api/v1beta1/restore_webhook.go
@@ -81,6 +81,11 @@ func (r *Restore) ValidateDelete(ctx context.Context, obj runtime.Object) (admis
 func (r *Restore) validateRestore() (admission.Warnings, error) {
 	var warnings admission.Warnings
 
+	// Validate namespaceMapping does not target protected system namespaces
+	if err := r.validateNamespaceMapping(); err != nil {
+		return warnings, err
+	}
+
 	// Validate sync mode configuration
 	if r.Spec.SyncRestoreWithNewBackups {
 		if err := r.validateSyncMode(); err != nil {
@@ -89,6 +94,34 @@ func (r *Restore) validateRestore() (admission.Warnings, error) {
 	}
 
 	return warnings, nil
+}
+
+// isProtectedNamespaceMappingTarget returns true if the namespace is a
+// platform-reserved namespace that must never be a NamespaceMapping target.
+// Velero applies restored objects with a near-cluster-admin ServiceAccount,
+// so allowing a Restore author to redirect backed-up Secrets/ConfigMaps into
+// kube-* or openshift-* namespaces is a cross-namespace write primitive.
+func isProtectedNamespaceMappingTarget(ns string) bool {
+	ns = strings.ToLower(strings.TrimSpace(ns))
+	return ns == "default" ||
+		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
+		strings.HasPrefix(ns, "kube-") ||
+		strings.HasPrefix(ns, "openshift-")
+}
+
+// validateNamespaceMapping rejects NamespaceMapping entries whose target is a
+// protected system namespace. NamespaceMapping is passed verbatim to the
+// emitted Velero Restore, so this check is the only guard between a Restore
+// author and Velero create/update of arbitrary objects in system namespaces.
+func (r *Restore) validateNamespaceMapping() error {
+	for src, dst := range r.Spec.NamespaceMapping {
+		if isProtectedNamespaceMappingTarget(dst) {
+			return fmt.Errorf(
+				"spec.namespaceMapping[%q]: target namespace %q is a protected system "+
+					"namespace and may not be used as a restore destination", src, dst)
+		}
+	}
+	return nil
 }
 
 // validateSyncMode validates sync mode specific requirements

--- a/api/v1beta1/restore_webhook.go
+++ b/api/v1beta1/restore_webhook.go
@@ -103,7 +103,7 @@ func (r *Restore) validateRestore() (admission.Warnings, error) {
 // kube-* or openshift-* namespaces is a cross-namespace write primitive.
 func isProtectedNamespaceMappingTarget(ns string) bool {
 	ns = strings.ToLower(strings.TrimSpace(ns))
-	return ns == "default" ||
+	return ns == "default" || ns == "openshift" ||
 		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
 		strings.HasPrefix(ns, "kube-") ||
 		strings.HasPrefix(ns, "openshift-")

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -131,6 +131,16 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			errSubstr: "protected system namespace",
 		},
 		{
+			name: "invalid namespaceMapping - exact openshift target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "openshift"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
 			name: "invalid namespaceMapping - default target",
 			restore: &Restore{
 				Spec: RestoreSpec{

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -111,6 +111,45 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			errSubstr: "must initially be set to 'skip'",
 		},
 		{
+			name: "invalid namespaceMapping - kube-system target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"src-ns": "kube-system"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "invalid namespaceMapping - openshift-config target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "openshift-config"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "invalid namespaceMapping - default target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "default"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
+			name: "valid namespaceMapping - non-system target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"old-ns": "new-acm-ns"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid sync - MC latest when Phase=Enabled (activation)",
 			restore: &Restore{
 				Spec: RestoreSpec{

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -38,10 +38,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "valid non-sync restore",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        false,
-					VeleroManagedClustersBackupName:  &specificBackup,
-					VeleroCredentialsBackupName:      &specificBackup,
-					VeleroResourcesBackupName:        &specificBackup,
+					SyncRestoreWithNewBackups:       false,
+					VeleroManagedClustersBackupName: &specificBackup,
+					VeleroCredentialsBackupName:     &specificBackup,
+					VeleroResourcesBackupName:       &specificBackup,
 				},
 			},
 			wantErr: false,
@@ -50,10 +50,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "valid sync restore with skip",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &skip,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &skip,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &latest,
 				},
 			},
 			wantErr: false,
@@ -62,10 +62,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "invalid sync - MC specific backup",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &specificBackup,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &specificBackup,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &latest,
 				},
 			},
 			wantErr:   true,
@@ -75,10 +75,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "invalid sync - creds not latest",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &skip,
-					VeleroCredentialsBackupName:      &specificBackup,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &skip,
+					VeleroCredentialsBackupName:     &specificBackup,
+					VeleroResourcesBackupName:       &latest,
 				},
 			},
 			wantErr:   true,
@@ -88,10 +88,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "invalid sync - resources not latest",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &skip,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &specificBackup,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &skip,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &specificBackup,
 				},
 			},
 			wantErr:   true,
@@ -101,10 +101,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "invalid sync - MC latest on initial create",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &latest,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &latest,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &latest,
 				},
 			},
 			wantErr:   true,
@@ -163,10 +163,10 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			name: "valid sync - MC latest when Phase=Enabled (activation)",
 			restore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &latest,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &latest,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &latest,
 				},
 				Status: RestoreStatus{
 					Phase: RestorePhaseEnabled,
@@ -206,10 +206,10 @@ func TestRestore_ValidateUpdate(t *testing.T) {
 			name: "valid update - activation from skip to latest",
 			oldRestore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &skip,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &skip,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &latest,
 				},
 				Status: RestoreStatus{
 					Phase: RestorePhaseEnabled,
@@ -217,10 +217,10 @@ func TestRestore_ValidateUpdate(t *testing.T) {
 			},
 			newRestore: &Restore{
 				Spec: RestoreSpec{
-					SyncRestoreWithNewBackups:        true,
-					VeleroManagedClustersBackupName:  &latest,
-					VeleroCredentialsBackupName:      &latest,
-					VeleroResourcesBackupName:        &latest,
+					SyncRestoreWithNewBackups:       true,
+					VeleroManagedClustersBackupName: &latest,
+					VeleroCredentialsBackupName:     &latest,
+					VeleroResourcesBackupName:       &latest,
 				},
 				Status: RestoreStatus{
 					Phase: RestorePhaseEnabled,
@@ -239,4 +239,3 @@ func TestRestore_ValidateUpdate(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## Summary

Backport of https://github.com/stolostron/cluster-backup-operator/pull/1698 to `release-2.16`.

**CVE:** CVE-2026-66799

The admission webhook now rejects `Restore` CRs whose `namespaceMapping` targets fall into a protected system namespace (`default`, `kube-*`, `openshift-*`).

## Test plan

- [x] `go mod verify`
- [x] `go build ./...`
- [x] `go test ./api/v1beta1/`

Related: ACM-38851

Made with [Cursor](https://cursor.com)