### PR TITLE
fix: reject Restore.spec.namespaceMapping targets in protected system namespaces [rhacm-2.15]

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -808,7 +808,7 @@ func setOptionalProperties(
 // kube-* or openshift-* namespaces is a cross-namespace write primitive.
 func isProtectedNamespaceMappingTarget(ns string) bool {
 	ns = strings.ToLower(strings.TrimSpace(ns))
-	return ns == "default" ||
+	return ns == "default" || ns == "openshift" ||
 		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
 		strings.HasPrefix(ns, "kube-") ||
 		strings.HasPrefix(ns, "openshift-")

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -737,7 +737,10 @@ func processRetrieveRestoreDetails(
 				labels[BackupScheduleClusterLabel] = veleroBackup.GetLabels()[BackupScheduleClusterLabel]
 				veleroRestore.SetLabels(labels)
 
-				setOptionalProperties(key, acmRestore, veleroRestore)
+				if err := setOptionalProperties(key, acmRestore, veleroRestore); err != nil {
+					acmRestore.Status.LastMessage = err.Error()
+					return veleroRestoresToCreate, err
+				}
 
 				if err := ctrl.SetControllerReference(acmRestore, veleroRestore, s); err != nil {
 					acmRestore.Status.LastMessage = fmt.Sprintf(
@@ -757,7 +760,7 @@ func setOptionalProperties(
 	key ResourceType,
 	acmRestore *v1beta1.Restore,
 	veleroRestore *veleroapi.Restore,
-) {
+) error {
 	// set includeClusterResources for all restores except credentials
 	if key == Resources || key == ManagedClusters || key == ResourcesGeneric {
 		var clusterResource = true
@@ -790,8 +793,41 @@ func setOptionalProperties(
 
 	// allow namespace mapping
 	if acmRestore.Spec.NamespaceMapping != nil {
+		if err := validateNamespaceMapping(acmRestore.Spec.NamespaceMapping); err != nil {
+			return err
+		}
 		veleroRestore.Spec.NamespaceMapping = acmRestore.Spec.NamespaceMapping
 	}
+	return nil
+}
+
+// isProtectedNamespaceMappingTarget returns true if the namespace is a
+// platform-reserved namespace that must never be a NamespaceMapping target.
+// Velero applies restored objects with a near-cluster-admin ServiceAccount,
+// so allowing a Restore author to redirect backed-up Secrets/ConfigMaps into
+// kube-* or openshift-* namespaces is a cross-namespace write primitive.
+func isProtectedNamespaceMappingTarget(ns string) bool {
+	ns = strings.ToLower(strings.TrimSpace(ns))
+	return ns == "default" ||
+		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
+		strings.HasPrefix(ns, "kube-") ||
+		strings.HasPrefix(ns, "openshift-")
+}
+
+// validateNamespaceMapping rejects NamespaceMapping entries whose target is a
+// protected system namespace. NamespaceMapping is passed verbatim to the
+// emitted Velero Restore, so this check is the only guard between a Restore
+// author and Velero create/update of arbitrary objects in system namespaces
+// on branches that do not yet run the Restore validating webhook.
+func validateNamespaceMapping(mapping map[string]string) error {
+	for src, dst := range mapping {
+		if isProtectedNamespaceMappingTarget(dst) {
+			return fmt.Errorf(
+				"spec.namespaceMapping[%q]: target namespace %q is a protected system "+
+					"namespace and may not be used as a restore destination", src, dst)
+		}
+	}
+	return nil
 }
 
 // set user options for resource filtering

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1340,6 +1340,11 @@ func Test_validateNamespaceMapping(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "invalid exact openshift target",
+			mapping: map[string]string{"hive-creds": "openshift"},
+			wantErr: true,
+		},
+		{
 			name:    "invalid default target",
 			mapping: map[string]string{"hive-creds": "default"},
 			wantErr: true,

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1312,10 +1312,52 @@ func Test_setOptionalProperties(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setOptionalProperties(tt.args.restype, tt.args.acmRestore, tt.args.veleroRestore)
+			if err := setOptionalProperties(tt.args.restype, tt.args.acmRestore, tt.args.veleroRestore); err != nil {
+				t.Fatalf("setOptionalProperties returned unexpected error: %v", err)
+			}
 			if !findValue(tt.args.veleroRestore.Spec.ExcludedResources, "CustomResourceDefinition") {
 				t.Errorf("CustomResourceDefinition should be excluded from restore and be part of " +
 					"veleroRestore.Spec.ExcludedResources")
+			}
+		})
+	}
+}
+
+func Test_validateNamespaceMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapping map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "invalid kube-system target",
+			mapping: map[string]string{"src-ns": "kube-system"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid openshift-config target",
+			mapping: map[string]string{"hive-creds": "openshift-config"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid default target",
+			mapping: map[string]string{"hive-creds": "default"},
+			wantErr: true,
+		},
+		{
+			name:    "valid non-system target",
+			mapping: map[string]string{"old-ns": "new-acm-ns"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNamespaceMapping(tt.mapping)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateNamespaceMapping() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "protected system namespace") {
+				t.Fatalf("expected protected system namespace error, got %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Backport of CVE-2026-66799 protection for `release-2.15`.

Upstream fix: https://github.com/stolostron/cluster-backup-operator/pull/1698 (webhook on `main`).

`release-2.15` does not include the Restore validating webhook, so this PR enforces the same protected-namespace check in the controller before `NamespaceMapping` is copied into the Velero Restore. Mappings to normal namespaces are unaffected.

Please add the `acknowledge-security-fixes-only` label (frozen branch).

## Test plan

- [x] `go mod verify`
- [x] `go build ./...`
- [x] `go test ./controllers/ -run 'Test_setOptionalProperties|Test_validateNamespaceMapping'`

Related: ACM-38847

Made with [Cursor](https://cursor.com)