### PR TITLE
fix: reject exact "openshift" namespace as a NamespaceMapping target

### DIFF
--- a/api/v1beta1/restore_webhook.go
+++ b/api/v1beta1/restore_webhook.go
@@ -83,7 +83,7 @@ func (r *Restore) validateRestore() (admission.Warnings, error) {
 // kube-* or openshift-* namespaces is a cross-namespace write primitive.
 func isProtectedNamespaceMappingTarget(ns string) bool {
 	ns = strings.ToLower(strings.TrimSpace(ns))
-	return ns == "default" ||
+	return ns == "default" || ns == "openshift" ||
 		ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" ||
 		strings.HasPrefix(ns, "kube-") ||
 		strings.HasPrefix(ns, "openshift-")

--- a/api/v1beta1/restore_webhook_test.go
+++ b/api/v1beta1/restore_webhook_test.go
@@ -131,6 +131,16 @@ func TestRestore_ValidateCreate(t *testing.T) {
 			errSubstr: "protected system namespace",
 		},
 		{
+			name: "invalid namespaceMapping - exact openshift target",
+			restore: &Restore{
+				Spec: RestoreSpec{
+					NamespaceMapping: map[string]string{"hive-creds": "openshift"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "protected system namespace",
+		},
+		{
 			name: "invalid namespaceMapping - default target",
 			restore: &Restore{
 				Spec: RestoreSpec{


### PR DESCRIPTION
## Summary

`isProtectedNamespaceMappingTarget` (added in #1698, part of the CVE-2026-66799 fix) rejects `Restore.spec.namespaceMapping` targets in `default`, `kube-*`, and `openshift-*` namespaces, but only checked the `openshift-` **prefix**, missing the exact `openshift` namespace itself.

`openshift` (no hyphen) is a separate, highly privileged, system-reserved OpenShift project (alongside `default`, `kube-system`, `kube-public`), so a `NamespaceMapping` targeting it should be rejected for the same reason as the other protected namespaces.

Caught by CodeRabbit while reviewing the release-2.17 backport of #1698.

## Changes

- `isProtectedNamespaceMappingTarget` now also rejects the exact `openshift` namespace.
- Added a regression test case for `NamespaceMapping` targeting `openshift`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./api/v1beta1/... -run TestRestore_ValidateCreate -v` — all cases pass, including the new `exact openshift target` case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restores targeting the `openshift` namespace are now blocked, preventing changes to this protected system namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->