### PR TITLE
fix: exclude RBAC and admission-control resources from Velero restore [rhacm-2.11]

### DIFF
--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -66,6 +66,26 @@ var (
 	}
 )
 
+// restoreExcludedClusterResources are always excluded from every Velero
+// Restore this operator emits, regardless of backup tarball contents or
+// user-supplied filters. The backup side (shouldBackupAPIGroup) never writes
+// rbac.authorization.k8s.io or admissionregistration.k8s.io into a legitimate
+// backup, so re-applying that boundary on the restore side is lossless and
+// prevents a tampered BackupStorageLocation tarball from injecting
+// privilege-escalating cluster-scoped objects when
+// IncludeClusterResources=true and ExistingResourcePolicy=update are set.
+var restoreExcludedClusterResources = []string{
+	"CustomResourceDefinition",
+	"clusterroles.rbac.authorization.k8s.io",
+	"clusterrolebindings.rbac.authorization.k8s.io",
+	"roles.rbac.authorization.k8s.io",
+	"rolebindings.rbac.authorization.k8s.io",
+	"mutatingwebhookconfigurations.admissionregistration.k8s.io",
+	"validatingwebhookconfigurations.admissionregistration.k8s.io",
+	"validatingadmissionpolicies.admissionregistration.k8s.io",
+	"validatingadmissionpolicybindings.admissionregistration.k8s.io",
+}
+
 func isVeleroRestoreFinished(restore *veleroapi.Restore) bool {
 	switch {
 	case restore == nil:
@@ -747,7 +767,10 @@ func setOptionalProperties(
 		veleroRestore.Spec.IncludeClusterResources = &clusterResource
 	}
 
-	veleroRestore.Spec.ExcludedResources = append(veleroRestore.Spec.ExcludedResources, "CustomResourceDefinition")
+	for i := range restoreExcludedClusterResources {
+		veleroRestore.Spec.ExcludedResources = appendUnique(veleroRestore.Spec.ExcludedResources,
+			restoreExcludedClusterResources[i])
+	}
 
 	// update existing resources if part of the new backup
 	veleroRestore.Spec.ExistingResourcePolicy = veleroapi.PolicyTypeUpdate

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -949,7 +949,17 @@ func Test_setOptionalProperties(t *testing.T) {
 			if !findValue(tt.args.veleroRestore.Spec.ExcludedResources, "CustomResourceDefinition") {
 				t.Errorf("CustomResourceDefinition should be excluded from restore and be part of veleroRestore.Spec.ExcludedResources")
 			}
-
+			for _, excluded := range restoreExcludedClusterResources {
+				if !findValue(tt.args.veleroRestore.Spec.ExcludedResources, excluded) {
+					t.Errorf("%q should always be excluded from restore and be part of "+
+						"veleroRestore.Spec.ExcludedResources", excluded)
+				}
+			}
+			if !findValue(tt.args.veleroRestore.Spec.ExcludedResources,
+				"clusterrolebindings.rbac.authorization.k8s.io") {
+				t.Errorf("clusterrolebindings.rbac.authorization.k8s.io must be excluded from restore " +
+					"regardless of backup tarball contents")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

**CVE:** CVE-2026-66797

Backport of #1696 to this branch.

Velero `Restore` requests created by this operator use `IncludeClusterResources=true` and `ExistingResourcePolicy=update`, which allows a supplied backup tarball to create or update cluster-scoped RBAC and admission-control objects on restore:

- `ClusterRole`, `ClusterRoleBinding`, `Role`, `RoleBinding`
- `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`
- `ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicyBinding`

The backup path never intentionally includes these resource types, so excluding them on restore closes an unnecessary widening of the restore's blast radius without affecting any supported workflow.

## Changes

- Add the above resource types to the Velero `Restore.spec.excludedResources` list this operator always sets (alongside the existing `CustomResourceDefinition` exclusion).
- Add unit test coverage confirming the exclusion list is applied.

## Test plan

- `make test` passes (build, vet, lint, unit tests all green; no manifest/generated-code drift).
- No breaking changes: the excluded resource types were never intentionally part of this operator's backups.
