### PR TITLE
fix: stop propagating Restore.spec.hooks to the underlying Velero restore [rhacm-2.14]

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -113,7 +113,13 @@ type RestoreSpec struct {
 	// +nullable
 	PreserveNodePorts *bool `json:"preserveNodePorts,omitempty"`
 
-	// velero option -  Hooks represent custom behaviors that should be executed during or post restore.
+	// Hooks is accepted for backward compatibility but is NOT propagated to the
+	// underlying Velero Restore and has no effect: Velero restore hooks execute
+	// commands inside restored pods using this operator's own permissions, which
+	// would let a Restore author run arbitrary commands they are not otherwise
+	// authorized to run. A Warning event is emitted on the Restore when this
+	// field is set. Users who need Velero restore hooks must create a Velero
+	// Restore directly and hold the RBAC to do so.
 	// +optional
 	Hooks veleroapi.RestoreHooks `json:"hooks,omitempty"`
 

--- a/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
+++ b/config/crd/bases/cluster.open-cluster-management.io_restores.yaml
@@ -76,8 +76,14 @@ spec:
                 nullable: true
                 type: array
               hooks:
-                description: velero option -  Hooks represent custom behaviors that
-                  should be executed during or post restore.
+                description: |-
+                  Hooks is accepted for backward compatibility but is NOT propagated to the
+                  underlying Velero Restore and has no effect: Velero restore hooks execute
+                  commands inside restored pods using this operator's own permissions, which
+                  would let a Restore author run arbitrary commands they are not otherwise
+                  authorized to run. A Warning event is emitted on the Restore when this
+                  field is set. Users who need Velero restore hooks must create a Velero
+                  Restore directly and hold the RBAC to do so.
                 properties:
                   resources:
                     items:

--- a/controllers/restore.go
+++ b/controllers/restore.go
@@ -782,11 +782,14 @@ func setOptionalProperties(
 	if acmRestore.Spec.RestorePVs != nil {
 		veleroRestore.Spec.RestorePVs = acmRestore.Spec.RestorePVs
 	}
-	if len(acmRestore.Spec.Hooks.Resources) > 0 {
-		veleroRestore.Spec.Hooks.Resources = append(veleroRestore.Spec.Hooks.Resources,
-			acmRestore.Spec.Hooks.Resources...,
-		)
-	}
+	// Restore.spec.hooks is intentionally NOT propagated to the emitted Velero
+	// Restore. RestoreResourceHookSpec carries PostHooks[].Exec.Command and
+	// Init container specs which Velero executes inside restored pods with its
+	// own ServiceAccount, giving an ACM Restore author a pods/exec-equivalent
+	// primitive they were not granted directly (confused deputy). The operator
+	// itself never requires restore hooks for ACM resources; users who need
+	// Velero restore hooks must hold create on restores.velero.io and supply
+	// them on a Velero Restore directly.
 
 	// set user options for resource filtering
 	setUserRestoreFilters(acmRestore, veleroRestore)

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -171,6 +171,23 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	// spec.hooks is accepted by the CRD but intentionally not propagated to the
+	// emitted Velero restore (see setOptionalProperties) since it would let a
+	// Restore author execute arbitrary commands inside restored pods using the
+	// operator's own permissions. Surface that as a Warning event rather than
+	// silently ignoring it.
+	if len(restore.Spec.Hooks.Resources) > 0 {
+		r.Recorder.Event(
+			restore,
+			v1.EventTypeWarning,
+			"RestoreHooksNotSupported",
+			"spec.hooks is specified but is not propagated to the underlying Velero restore for "+
+				"security reasons (restore hooks execute commands inside restored pods using the "+
+				"operator's own permissions, which is a privilege-escalation risk); hooks will not "+
+				"run. If you require restore hooks, create a Velero Restore directly instead.",
+		)
+	}
+
 	// don't create restores if there is any other active resource in this namespace
 	activeResourceMsg, err := isOtherResourcesRunning(ctx, r.Client, restore)
 	if err != nil {

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -346,8 +346,9 @@ var _ = Describe("Basic Restore controller", func() {
 				Expect(*veleroRestores.Items[i].Spec.PreserveNodePorts).Should(BeTrue())
 				Expect(veleroRestores.Items[i].Spec.RestoreStatus.IncludedResources[0]).
 					Should(BeIdenticalTo("webhook"))
-				Expect(veleroRestores.Items[i].Spec.Hooks.Resources[0].Name).Should(
-					BeIdenticalTo("hookName"))
+				// spec.hooks must NOT be propagated to the Velero Restore
+				// (pods/exec-equivalent confused-deputy primitive)
+				Expect(veleroRestores.Items[i].Spec.Hooks.Resources).Should(BeEmpty())
 				Expect(veleroRestores.Items[i].Spec.ExcludedNamespaces).Should(
 					ContainElement("ns1"))
 				Expect(veleroRestores.Items[i].Spec.IncludedNamespaces).Should(
@@ -430,6 +431,67 @@ var _ = Describe("Basic Restore controller", func() {
 				}
 				return createdRestore.Status.CompletionTimestamp
 			}, timeout, interval).ShouldNot(BeNil())
+		})
+	})
+
+	Context("When creating a Restore with spec.hooks set", func() {
+		BeforeEach(func() {
+			// Use a dedicated namespace (like the other Contexts in this Describe)
+			// instead of the shared default, to avoid racing the previous test's
+			// namespace cleanup. Redirect the already-built default fixtures
+			// (from the outer BeforeEach) onto the new namespace.
+			veleroNamespace = createNamespace("velero-restore-ns-hooks")
+			backupStorageLocation.Namespace = veleroNamespace.Name
+			rhacmRestore.Namespace = veleroNamespace.Name
+			for i := range veleroBackups {
+				veleroBackups[i].Namespace = veleroNamespace.Name
+			}
+
+			// spec.hooks is accepted by the CRD but must never be propagated to the
+			// emitted Velero restore (security fix); instead the controller should
+			// emit a Warning event so the omission is observable.
+			rhacmRestore.Spec.Hooks.Resources = []veleroapi.RestoreResourceHookSpec{
+				{Name: "test-hook"},
+			}
+		})
+
+		It("should not propagate hooks to velero restores and should emit a Warning event", func() {
+			restoreLookupKey := types.NamespacedName{Name: restoreName, Namespace: veleroNamespace.Name}
+			createdRestore := v1beta1.Restore{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, restoreLookupKey, &createdRestore)
+			}, timeout, interval).Should(Succeed())
+
+			By("velero restores should never receive spec.hooks")
+			Eventually(func() int {
+				veleroRestores := veleroapi.RestoreList{}
+				if err := k8sClient.List(ctx, &veleroRestores, client.InNamespace(veleroNamespace.Name)); err != nil {
+					return -1
+				}
+				return len(veleroRestores.Items)
+			}, timeout, interval).Should(BeNumerically(">", 0))
+
+			veleroRestores := veleroapi.RestoreList{}
+			Expect(k8sClient.List(ctx, &veleroRestores, client.InNamespace(veleroNamespace.Name))).To(Succeed())
+			for i := range veleroRestores.Items {
+				Expect(veleroRestores.Items[i].Spec.Hooks.Resources).To(BeEmpty())
+			}
+
+			By("a Warning event should be recorded on the restore")
+			Eventually(func() bool {
+				events := &corev1.EventList{}
+				if err := k8sClient.List(ctx, events, client.InNamespace(veleroNamespace.Name)); err != nil {
+					return false
+				}
+				for i := range events.Items {
+					if events.Items[i].InvolvedObject.Name == restoreName &&
+						events.Items[i].Reason == "RestoreHooksNotSupported" &&
+						events.Items[i].Type == corev1.EventTypeWarning {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/controllers/restore_test.go
+++ b/controllers/restore_test.go
@@ -1062,6 +1062,29 @@ func Test_validateNamespaceMapping(t *testing.T) {
 	}
 }
 
+// Test_setOptionalProperties_HooksNotPropagated verifies that
+// Restore.spec.hooks is never copied onto the emitted Velero Restore.
+// Velero RestoreResourceHookSpec carries PostHooks[].Exec.Command which
+// Velero executes inside restored pods; propagating it would give an ACM
+// Restore author a pods/exec-equivalent primitive they were not granted.
+func Test_setOptionalProperties_HooksNotPropagated(t *testing.T) {
+	acmRestore := createACMRestore("acm-restore", "ns").
+		veleroManagedClustersBackupName("skip").
+		veleroCredentialsBackupName(latestBackupStr).
+		veleroResourcesBackupName(latestBackupStr).
+		hookResources([]veleroapi.RestoreResourceHookSpec{{Name: "pwn"}}).object
+	veleroRestore := createRestore("resources-restore", "ns").object
+
+	if err := setOptionalProperties(Resources, acmRestore, veleroRestore); err != nil {
+		t.Fatalf("setOptionalProperties() error = %v", err)
+	}
+
+	if len(veleroRestore.Spec.Hooks.Resources) != 0 {
+		t.Errorf("Restore.spec.hooks must not be propagated to the Velero Restore, "+
+			"got %d hook resource(s)", len(veleroRestore.Spec.Hooks.Resources))
+	}
+}
+
 func Test_retrieveRestoreDetails(t *testing.T) {
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{


### PR DESCRIPTION
## Summary

**CVE:** CVE-2026-66798

Backport of #1697 to this branch.

`Restore.spec.hooks` was passed through verbatim to the Velero `Restore` object this operator creates. Velero restore hooks execute arbitrary commands inside restored pods using the operator's own permissions, so any principal able to create a `Restore` CR could use `spec.hooks` to run commands with the operator's privileges, without needing any pod-exec RBAC of their own.

## Changes

- `spec.hooks` is no longer propagated to the underlying Velero `Restore`.
- A `Warning` event (`RestoreHooksNotSupported`) is emitted on the `Restore` CR when `spec.hooks` is set, so the omission is observable rather than silent.
- Add unit test coverage confirming hooks are never propagated.

## Test plan

- `make test` passes (build, vet, lint, unit tests all green; no manifest/generated-code drift).
- Breaking change (documented): any automation relying on `spec.hooks` executing during restore will need to be updated — hooks silently ceasing to run is called out via the new Warning event.
