### PR TITLE
fix: require explicit confirmation annotation for CleanupAll restores [release-2.17]

### DIFF
--- a/api/v1beta1/restore_types.go
+++ b/api/v1beta1/restore_types.go
@@ -62,6 +62,14 @@ const (
 	CleanupTypeAll = "CleanupAll"
 )
 
+// RestoreCleanupAllAnnotation must be present on a Restore CR with value
+// "true" for cleanupBeforeRestore=CleanupAll to be honored. CleanupAll drives
+// the operator ServiceAccount to mass-delete ACM-scoped Secrets, ConfigMaps
+// and discovered CRs that are not in the selected backup, so it is gated
+// behind an explicit per-Restore acknowledgement rather than being reachable
+// from spec alone.
+const RestoreCleanupAllAnnotation = "cluster.open-cluster-management.io/restore-cleanup-all-confirmed"
+
 // RestoreSpec defines the desired state of Restore
 type RestoreSpec struct {
 	// VeleroManagedClustersBackupName is the name of the velero back-up used to restore managed clusters.

--- a/controllers/create_helper_test.go
+++ b/controllers/create_helper_test.go
@@ -380,6 +380,16 @@ func (b *ACMRestoreHelper) setFinalizer(values []string) *ACMRestoreHelper {
 
 func (b *ACMRestoreHelper) cleanupBeforeRestore(cleanup v1beta1.CleanupType) *ACMRestoreHelper {
 	b.object.Spec.CleanupBeforeRestore = cleanup
+	if string(cleanup) == v1beta1.CleanupTypeAll {
+		// test fixtures that exercise CleanupAll model an admin who has
+		// explicitly acknowledged the destructive operation
+		ann := b.object.GetAnnotations()
+		if ann == nil {
+			ann = map[string]string{}
+		}
+		ann[v1beta1.RestoreCleanupAllAnnotation] = "true"
+		b.object.SetAnnotations(ann)
+	}
 	return b
 }
 

--- a/controllers/restore_post.go
+++ b/controllers/restore_post.go
@@ -754,6 +754,17 @@ func isValidCleanupOption(
 
 	}
 
+	// CleanupAll drives the operator ServiceAccount to mass-delete ACM-scoped
+	// resources not present in the selected backup, including user-created
+	// hub resources. Require an explicit per-Restore acknowledgement so the
+	// destructive path cannot be reached from spec.cleanupBeforeRestore alone.
+	if string(acmRestore.Spec.CleanupBeforeRestore) == v1beta1.CleanupTypeAll &&
+		acmRestore.GetAnnotations()[v1beta1.RestoreCleanupAllAnnotation] != "true" {
+		return "cleanupBeforeRestore=CleanupAll requires the " +
+			v1beta1.RestoreCleanupAllAnnotation + "=true annotation on the Restore " +
+			"resource to confirm mass deletion of ACM-scoped hub resources"
+	}
+
 	return ""
 }
 

--- a/controllers/restore_post_test.go
+++ b/controllers/restore_post_test.go
@@ -3189,3 +3189,37 @@ func Test_deleteOlderRestoreClustersBackups(t *testing.T) {
 		})
 	}
 }
+
+// Test_isValidCleanupOption_CleanupAllRequiresAnnotation verifies that
+// cleanupBeforeRestore=CleanupAll is rejected unless the Restore CR carries
+// the explicit RestoreCleanupAllAnnotation acknowledgement. The guard runs
+// in Reconcile before any Velero Restore is created or any cleanup runs,
+// so a Restore author without the annotation cannot drive the operator
+// ServiceAccount to mass-delete hub resources.
+func Test_isValidCleanupOption_CleanupAllRequiresAnnotation(t *testing.T) {
+	withoutAnnotation := &v1beta1.Restore{
+		Spec: v1beta1.RestoreSpec{CleanupBeforeRestore: v1beta1.CleanupTypeAll},
+	}
+	if msg := isValidCleanupOption(withoutAnnotation); msg == "" {
+		t.Errorf("CleanupAll without %s annotation must be rejected",
+			v1beta1.RestoreCleanupAllAnnotation)
+	}
+
+	withAnnotation := &v1beta1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{v1beta1.RestoreCleanupAllAnnotation: "true"},
+		},
+		Spec: v1beta1.RestoreSpec{CleanupBeforeRestore: v1beta1.CleanupTypeAll},
+	}
+	if msg := isValidCleanupOption(withAnnotation); msg != "" {
+		t.Errorf("CleanupAll with %s=true annotation must be accepted, got: %s",
+			v1beta1.RestoreCleanupAllAnnotation, msg)
+	}
+
+	restored := &v1beta1.Restore{
+		Spec: v1beta1.RestoreSpec{CleanupBeforeRestore: v1beta1.CleanupTypeRestored},
+	}
+	if msg := isValidCleanupOption(restored); msg != "" {
+		t.Errorf("CleanupRestored without annotation must be accepted, got: %s", msg)
+	}
+}


### PR DESCRIPTION
## Summary

**CVE:** CVE-2026-66800

Backport of #1699 to this branch.

`cleanupBeforeRestore: CleanupAll` drives the operator's own ServiceAccount to mass-delete ACM-scoped Secrets, ConfigMaps, and discovered CRs that are not present in the selected backup. This was reachable from `Restore.spec` alone, so any principal able to create a `Restore` CR could trigger a broad, irreversible deletion across the hub using the operator's elevated permissions, independent of their own RBAC.

## Changes

- `CleanupAll` now additionally requires the `cluster.open-cluster-management.io/restore-cleanup-all-confirmed: "true"` annotation on the `Restore` CR. Without it, the controller rejects the request during reconciliation (`FinishedWithErrors`, with a status message naming the required annotation) before any cleanup or Velero restore is created, rather than silently running (or silently skipping) the cleanup. This check is controller-side, not admission-webhook-side — the `Restore` is accepted at `oc apply` time and then rejected on first reconcile, with the destructive path never reached in either case.
- Add unit test coverage for both the rejection and the annotated/allowed case.
- Test helpers updated so existing `CleanupAll` fixtures continue to pass with the annotation applied.

## Test plan

- `make test` passes (build, vet, lint, unit tests all green; no manifest/generated-code drift).
- Breaking change (documented, intentional): existing automation using `cleanupBeforeRestore: CleanupAll` without the new annotation will now have those restores rejected until the annotation is added. This fails loudly with a clear message rather than silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an explicit confirmation annotation for restore operations that remove all existing resources.

- **Bug Fixes**
  - Restore requests using the “clean up all” option are now rejected unless the required confirmation is provided, helping prevent accidental resource deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->