### PR TITLE
use PQC base img: https://redhat.atlassian.net/browse/ACM-41552

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=1 GOFLAGS='-mod=readonly' go build -tags strictfipsruntime -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.redhat.io/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG ACM_VERSION
 


### PR DESCRIPTION
Mirrors https://github.com/stolostron/volsync-addon-controller/pull/1477.

Switches the final-stage base image in `Dockerfile.rhtap` from `registry.redhat.io/ubi9/ubi-minimal:latest` to `registry.redhat.io/ubi9/ubi-minimal-pqc:latest` for post-quantum cryptography support.

Jira: https://redhat.atlassian.net/browse/ACM-41552

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment to use the latest post-quantum cryptography–enabled base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->